### PR TITLE
Fixed sidebar navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To build documentation, you first need to install the documentation-builder:
 snap install documentation-builder
 ```
 
-Now simply run it inside this folder:
+Then, navigate to the folder containing this repository and run the command
 
 ``` bash
 documentation-builder

--- a/en/index.md
+++ b/en/index.md
@@ -283,7 +283,7 @@ When writing out numbers over the 100s, remember to include commas.
 <!-- RULE
 #18 Separate input and output code blocks
 -->
-# Code examples in documentation
+## Code examples in documentation
 
 **DO NOT** use prompt marks (e.g. `$` or `#`) in code samples. These cause problems
 for users who sometimes mistakenly type them in, or who want to copy and paste

--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -18,21 +18,23 @@ navigation:
 
     - title: Spelling
       location: '#spelling'
+    - title: Branding
+      location: '#branding'
     - title: Contractions
       location: '#contractions'
-    - title: Headings and capitalisation
-      location: '#headings-and-capitalisation'
+    - title: Headings
+      location: '#headings'
     - title: Dates
       location: '#dates'
     - title: Numbers
       location: '#numbers'
     - title: Code examples in documentation
       location: '#code-examples-in-documentation'
-    - title: Hyperlinks
-      location: '#hyperlinks'
     - title: Images
       location: '#images'
     - title: Words and phrases to avoid
       location: '#words-and-phrases-to-avoid'
- 
-
+    - title: Interacting with UI elements
+      location: '#interacting-with-ui-elements'
+    - title: FAQs
+      location: '#faqs'


### PR DESCRIPTION
Issue:
- Headings in side navigation do not reflect actual page structure

Solution:
- Updated `en/metadata.yaml` with current heading structure
- Changed heading level of "Code examples in documentation"

**Note:** Slightly reworded README.md instructions for `documentation-builder` because they confused me a bit. 