### PR TITLE
fix rule comment

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -385,6 +385,7 @@ permitting users or customers to conduct certain activities.
 
 It can be tempting to use flowery, official-sounding words
 rather than plain English. Try to keep it simple.
+
 <!-- RULE
 #21 No double space after a period/full stop
 -->


### PR DESCRIPTION
I got this as a reference from 
@k-dimple in https://github.com/canonical/open-documentation-academy/issues/26#issue-2175647666 

and noticed one of the comments showing up in the preview:

![Screenshot 2024-04-09 174940](https://github.com/canonical/praecepta/assets/54991735/a226a684-3084-4dd1-8e93-1a352b412dbc)

this should fix it.
