### PR TITLE
Adds rule #09 - no links in headings

### DIFF
--- a/styles/Canonical/009-Headings-no-links.yml
+++ b/styles/Canonical/009-Headings-no-links.yml
@@ -1,5 +1,6 @@
 # 09 - Heading - Headings should not contain links
 
+name: 009
 extends: existence
 message: "Headings should not contain links"
 link: https://docs.ubuntu.com/styleguide/en/#other-considerations
@@ -11,9 +12,11 @@ tokens:
   - '[ \w]+\[[\w]+[ \w]*\]\([.\w]+\)[^\n]*\n[=-]{2,}\n'
   - '[\#]+ [ \w]+<http[^\n]+>'
   - '[ \w]+<http[^\n]+>[^\n]*\n[=-]{2,}\n'
-  - '[ \w]+`[ \w]*<[\.a-zA-Z0-9\/]+>`_\n(.)\1{3,}\n'
+  - '[ \w]+`[ \w]*<[\.a-zA-Z0-9\/]+>`_[ \w]*\n(.)\1{3,}\n'
   - '[ \w]+[ \w]*<[:\.a-zA-Z0-9\/]+>[ \w]*\n(.)\2{3,}\n'
   - '[ \w]+\:ref\:`[^\n]+`[ \w]*\n(.)\3{3,}\n'
   - '[ \w]+\:doc\:`[^\n]+`[ \w]*\n(.)\4{3,}\n'
   - '[ \w]+\{ref\}`[^\n]+`[ \w]*\n(.)\5{3,}\n'
   - '[ \w]+\{doc\}`[^\n]+`[ \w]*\n(.)\6{3,}\n'
+  - '[^\n]*https?:\/\/[^\n]*\n(.)\7{3,}\n'
+  - '[^\n]*www\.[^\n]*\n(.)\8{3,}\n'

--- a/test/test009.md
+++ b/test/test009.md
@@ -1,3 +1,5 @@
+<!-- To test, run `vale --filter '.Name=="Canonical.009-Headings-no-links"' test009.md` -->
+
 # Heading with [a link](docs.ubuntu.com) 
 
 Paragraph with [a link](docs.ubuntu.com).
@@ -16,6 +18,11 @@ RST heading with `a link<docs.ubuntu.com>`_ not at end of line
 ==============================================================
 
 RST paragraph with `a link<docs.ubuntu.com>`_
+
+RST heading with `a link <docs.ubuntu.com>`_ not at end of line
+===============================================================
+
+RST paragraph with `a link <docs.ubuntu.com>`_
 
 RST heading with a doc ref :doc:`some document`
 -----------------------------------------------
@@ -44,3 +51,19 @@ RST heading with a ref <project:../README.md> not at end of line
 ------------------------------------------------------------------
 
 RST paragraph with a ref ref <project:../README.md> 
+
+
+RST heading with www.example.com address
+========================================
+
+RST paragraph with www.example.com address.
+
+RST heading with http://example.com address
+========================================
+
+RST paragraph with http://example.com address.
+
+RST heading with https://example.com address
+========================================
+
+RST paragraph with https://example.com address.


### PR DESCRIPTION
Adds style rule to Canonical folder, and adds test3.md document to test rule against

Forced to operate on raw scope due to how Vale works with parsing contents.

Captures the following occurrences:
- Standard `[Markdown link](link)` in line starting with at least one `#`
- Obscure `<https://markdown.link>` in line starting with at least one `#`
- Above cases but with non-standard heading syntax (underlined with = or -)
- Standard RST link syntax
- RST doc and ref links
- and now `{ref}`, `{doc}`, and `<project:links>`