### PR TITLE
Adds rule 10 - no code in headings

### DIFF
--- a/styles/Canonical/009-Headings-no-links.yml
+++ b/styles/Canonical/009-Headings-no-links.yml
@@ -1,6 +1,5 @@
 # 09 - Heading - Headings should not contain links
 
-name: 009
 extends: existence
 message: "Headings should not contain links"
 link: https://docs.ubuntu.com/styleguide/en/#other-considerations

--- a/styles/Canonical/010-Headings-no-code.yml
+++ b/styles/Canonical/010-Headings-no-code.yml
@@ -1,0 +1,13 @@
+# 10 - Heading - Headings should not contain code
+
+extends: existence
+message: "Headings should not contain code"
+link: https://docs.ubuntu.com/styleguide/en/#other-considerations
+nonword: true
+level: warning
+scope: raw
+tokens:
+  - '[\#]+[ \w]*`[ \w]+`[ \w]*'
+  - '[ \w]*`[ \w]+`[ \w]*\n[=-]{2,}\n'
+  - '[ \w]+\:code\:`[^\n]+`[ \w]*\n(.)\1{3,}\n'
+  - '[ \w]+``[^\n]+``[ \w]*\n(.)\2{3,}\n'

--- a/styles/Canonical/021-Punctuation-double-spaces.yml
+++ b/styles/Canonical/021-Punctuation-double-spaces.yml
@@ -1,4 +1,4 @@
-# 10 - Punctuation - No double space after '.', `?`, or `!`
+# 21 - Punctuation - No double space after '.', `?`, or `!`
 
 extends: existence
 message: "'%s' should have one space."

--- a/test/test010.md
+++ b/test/test010.md
@@ -1,0 +1,20 @@
+<!-- To test, run `vale --filter '.Name=="Canonical.010-Headings-no-code"' test010.md` -->
+
+Test `code`
+===========
+
+`Test` code
+===========
+
+`Test code`
+===========
+
+# No code
+
+# Some `code` here
+
+## Some `more code`
+
+## `All code`
+
+## `Additional` code


### PR DESCRIPTION
- Changes double spacing rule to proper number as indicated in issue
- Adds testing for rule 10
- Removes superfluous field from rule 09

As in rule 9, needs to target raw content.