### PR TITLE
Identify repeated words

### DIFF
--- a/styles/Canonical/000-Repeated-words.yml
+++ b/styles/Canonical/000-Repeated-words.yml
@@ -1,0 +1,7 @@
+extends: repetition
+message: "'%s' is repeated!"
+level: error
+alpha: true
+ignorecase: true
+tokens:
+  - '[^\s]+'

--- a/styles/Canonical/000-Repeated-words.yml
+++ b/styles/Canonical/000-Repeated-words.yml
@@ -1,6 +1,6 @@
 extends: repetition
 message: "'%s' is repeated!"
-level: error
+level: warning
 alpha: true
 ignorecase: true
 tokens:


### PR DESCRIPTION
Call out when two successively repeated words are used (e.g. "I went to the the store."). This happens very often and it's hard to catch since the words are fine in themselves.

This rule is not implementing the Canonical style guide. It is identifying a syntactical error. Because of this, I chose the numbering scheme of '000-Some-rule'. If we agree to this format for outright mistakes, I can make an addition to the README explaining it.