### PR TITLE
DOCPR-381: Vale rule no. 11 no stacked headings

### DIFF
--- a/styles/Canonical/011-Headings-not-followed-by-heading.yml
+++ b/styles/Canonical/011-Headings-not-followed-by-heading.yml
@@ -1,0 +1,10 @@
+extends: existence
+message: "Avoid stacked headings. There should be content for each heading."
+nonword: true
+scope: raw
+level: error
+tokens:
+  # Regex for Markdown.
+  - '(?m)^#{1,5}\s[^\n]*\n(\s*\n\s*)*^#{1,5}\s[^\n]*$'
+  # Regex for reStructuredText.
+  - '(?m)^[^\n]+(\n[-=~^.]+)\n(\s*\n\s*)*^[^\n]+(\n[-=~^.]+)$'

--- a/test/test011.md
+++ b/test/test011.md
@@ -1,0 +1,59 @@
+# Heading 1 - positive test cases
+
+This section is for positive test cases. Each heading has intervening text
+before the next heading is declared.
+
+# Heading 1 - positive - same level headings
+
+For this positive test case, a level 1 heading is followed by a level 1 heading.
+
+## Heading 2 - positive - subheading
+
+For this positive test case, a level 1 heading is followed by a level 2 heading.
+
+## Heading 2 - positive - same level headings
+
+For this positive test case, a level 2 heading is followed by a level 2 heading.
+
+### Heading 3 - positive - subheading
+
+For this positive test case, a level 2 heading is followed by a level 3 heading.
+
+### Heading 3 - positive - same level headings
+
+For this positive test case, a level 3 heading is followed by a level 3 heading.
+
+#### Heading 4 - positive - subheading
+
+For this positive test case, a level 3 heading is followed by a level 4 heading.
+
+#### Heading 4 - positive - same level headings
+
+For this positive test case, a level 4 heading is followed by a level 4 heading.
+
+# Heading 1 - positive - new section
+
+For this positive test case, a level 4 heading is followed by a level 1 heading.
+
+# Heading 1 - negative test cases
+
+This section is for negative test cases. Each heading does not have intervening
+text before the next heading is declared.
+
+This test case should return four errors.
+
+# Heading 1 - negative - same level headings
+
+## Heading 2 - negative - subheading
+
+## Heading 2 - negative - same level headings
+
+### Heading 3 - negative - subheading
+
+### Heading 3 - negative - same level headings
+
+#### Heading 4 - negative - subheading
+
+#### Heading 4 - negative - same level headings
+
+# Heading 1 - negative - new section

--- a/test/test011.rst
+++ b/test/test011.rst
@@ -1,0 +1,77 @@
+Heading 1 - positive test cases
+===============================
+
+This section is for positive test cases. Each heading has intervening text
+before the next heading is declared.
+
+Heading 1 - positive - same level headings
+==========================================
+
+For this positive test case, a level 1 heading is followed by a level 1 heading.
+
+Heading 2 - positive - subheading
+---------------------------------
+
+For this positive test case, a level 1 heading is followed by a level 2 heading.
+
+Heading 2 - positive - same level headings
+------------------------------------------
+
+For this positive test case, a level 2 heading is followed by a level 2 heading.
+
+Heading 3 - positive - subheading
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For this positive test case, a level 2 heading is followed by a level 3 heading.
+
+Heading 3 - positive - same level headings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For this positive test case, a level 3 heading is followed by a level 3 heading.
+
+Heading 4 - positive - subheading
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For this positive test case, a level 3 heading is followed by a level 4 heading.
+
+Heading 4 - positive - same level headings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For this positive test case, a level 4 heading is followed by a level 4 heading.
+
+Heading 1 - positive - new section
+==================================
+
+For this positive test case, a level 4 heading is followed by a level 1 heading.
+
+Heading 1 - negative test cases
+===============================
+
+This section is for negative test cases. Each heading does not have intervening
+text before the next heading is declared.
+
+This test case should return four errors.
+
+Heading 1 - negative - same level headings
+==========================================
+
+Heading 2 - negative - subheading
+---------------------------------
+
+Heading 2 - negative - same level headings
+------------------------------------------
+
+Heading 3 - negative - subheading
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Heading 3 - negative - same level headings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Heading 4 - negative - subheading
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Heading 4 - negative - same level headings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Heading 1 - negative - new section
+==================================


### PR DESCRIPTION
Hi @evilnick ,

This PR is for DOCPR-381.

I did make some changes w.r.t. the definition of this rule.

Headings of the same level can follow each other (e.g. H1 > H2 > H2) as long as there is intervening text in between.

So this rule checks for stacked headings (with no content under the heading) regardless if the consecutive headings are of the same level, or different levels. This would also help detect errors if headings are unintentionally defined in the source files but not expanded on.

I've added 2 test files with minimal test cases that should trigger errors for this rule.

Thanks!