### PR TITLE
DOCPR-371: Vale rule no. 01 British English check

### DIFF
--- a/styles/Canonical/001-English-words-spelling-suggestions.yml
+++ b/styles/Canonical/001-English-words-spelling-suggestions.yml
@@ -1,0 +1,99 @@
+extends: substitution
+message: "Use British English spelling, '%s' instead of '%s'."
+link: https://docs.ubuntu.com/styleguide/en/#spelling
+ignorecase: true
+level: suggestion
+action:
+  name: replace
+swap:
+  'acknowledgment': acknowledgement
+  'airplane': aeroplane
+  'aluminum': aluminium
+  'analog': analogue
+  'analyze': analyse
+  'annex': annexe
+  'apologize': apologise
+  'armor': armour
+  'authorization': authorisation
+  'authorize': authorise
+  'authorizer': authoriser
+  'behavior': behaviour
+  'canceled': cancelled
+  'capitalize': 'capitalise'
+  'catalog': catalogue
+  'center': centre
+  'checker': chequer
+  'cipher': cypher
+  'color': colour
+  'counseling': counselling
+  'counselor': counsellor
+  'defense': defence
+  'dialed': dialled
+  'dialer': dialler
+  'dialog': dialogue
+  'emphasize': emphasise
+  'encyclopedia': encyclopaedia
+  'endeavor': endeavour
+  'enrollment': enrolment
+  'equaling': equalling
+  'favor': favour
+  'favorite': favourite
+  'fiber': fibre
+  'flakey': flaky
+  'flavor': flavour
+  'fulfill': fulfil
+  'furor': furore
+  'generalize': generalise
+  'glycerin': glycerine
+  'gray': grey
+  'harbor': harbour
+  'harmonization': harmonisation
+  'harmonize': harmonise
+  'honor': honour
+  'humor': humour
+  'in side': inside
+  'industrialize': industrialise
+  'installment': instalment
+  'italicize': italicise
+  'judgment': judgement
+  'kilometer': kilometre
+  'labeled': labelled
+  'labor': labour
+  'license': licence
+  'liter': litre
+  'lodgement': lodgment
+  'maneuver': manoeuvre
+  'modeling': modelling
+  'mold': mould
+  'monolog': monologue
+  'offense': offence
+  'organization': organisation
+  'oriented': orientated
+  'parlor': parlour
+  'percent': per cent
+  'plow': plough
+  'practice': practise
+  'pretense': pretence
+  'quarreled': quarrelled
+  'quarreling': quarrelling
+  'realization': realisation
+  'realize': realise
+  'recognize': recognise
+  'rumor': rumour
+  'sausages, beans, and mash': sausages, beans and mash
+  'signaling': signalling
+  'skeptic': sceptic
+  'skeptical': sceptical
+  'skillful': skilful
+  'specialty': speciality
+  'theater': theatre
+  'tranquility': tranquillity
+  'traveled': travelled
+  'traveler': traveller
+  'traveling': travelling
+  'urbanization': urbanisation
+  'virtualize': virtualise
+  'virtualization': virtualisation
+  'whiskey': whisky
+  'woolen': woollen
+  'yogurt': yoghurt

--- a/styles/Canonical/001-English-words-spelling-suggestions.yml
+++ b/styles/Canonical/001-English-words-spelling-suggestions.yml
@@ -97,3 +97,4 @@ swap:
   'whiskey': whisky
   'woolen': woollen
   'yogurt': yoghurt
+  

--- a/test/test001.md
+++ b/test/test001.md
@@ -1,0 +1,26 @@
+This file contains negative test cases for rule #001.
+This test case should return 12 spelling suggestions.
+
+---
+
+The software update included an acknowledgment of all the contributors to the
+project.
+
+The new device uses analog signals to process sound more accurately.
+
+The team will analyze the data to improve the algorithm's efficiency.
+
+You need to authorize the app to access your location for better functionality.
+
+During the dialog with the user interface, we noticed several usability issues.
+
+The event was canceled due to unforeseen technical difficulties.
+
+This new ice cream flavor has quickly become a favorite among testers.
+
+To emphasize the keyword, you should italicize it in the documentation.
+
+The organization implemented a new cybersecurity protocol to protect its data.
+
+Virtualization technology makes it possible for multiple operating systems to
+run on a single hardware platform.


### PR DESCRIPTION
Hi @evilnick , @SecondSkoll ,

This PR is for DOCPR-371.

This rule is focused only on making suggestions for words using US spelling, to UK English spelling.
Style guide section: https://docs.ubuntu.com/styleguide/en/#spelling

~~I think it'll be better to create separate rules for common technology terms we want to standardise, e.g. "website" and not "web site". That would be cleaner to maintain and test.~~
[Update: I just realised this is indeed a separate rule in the style guide source itself.]

I also think it would be good to start following a proper naming convention for the test files we include.
E.g. for rule no. 011, the test file name would be test011.md or test011.rst, so we know which rules are expected to fail.

Thanks!