### PR TITLE
Add rule 004

### DIFF
--- a/styles/Canonical/004-Canonical-product-names.yml
+++ b/styles/Canonical/004-Canonical-product-names.yml
@@ -1,5 +1,5 @@
 extends: substitution
-message: "Did you really mean'%s' instead of '%s'?"
+message: "Did you really mean '%s' instead of '%s'?"
 link: https://docs.ubuntu.com/styleguide/en/#other-canonical-products
 ignorecase: false
 level: suggestion

--- a/styles/Canonical/004-Canonical-product-names.yml
+++ b/styles/Canonical/004-Canonical-product-names.yml
@@ -1,0 +1,37 @@
+extends: substitution
+message: "Did you really mean'%s' instead of '%s'?"
+link: https://docs.ubuntu.com/styleguide/en/#other-canonical-products
+ignorecase: false
+level: suggestion
+action:
+  name: replace
+swap:
+  'Anbox cloud': Anbox Cloud
+  'AnBox': Anbox
+  'Charmed kubeflow' : Charmed Kubeflow
+  'Canononical observability stack' : Canonical Observability Stack
+  'juju' : Juju
+  'JuJu' : Juju
+  'LandScape' : Landscape
+  'LaunchPad' : Launchpad
+  'lxd' : LXD
+  'MaaS' : MAAS
+  'Maas' : MAAS
+  'maas' : MAAS
+  'Microceph' : MicroCeph
+  'Microcloud' : MicroCloud
+  'Microk8s' : MicroK8s
+  'Microovn' : MicroOVN
+  'MicroOvn' : MicroOVN
+  'Microstack' : MicroStack
+  'microstack': MicroStack
+  'MultiPass' : Multipass
+  'multipass' : Multipass
+  'SnapCraft' : Snapcraft
+  'snapcraft' : Snapcraft
+  'snapD' : snapd
+  'Snapd' : snapd
+  'SnapD' : snapd
+  'Ubuntu pro' : Ubuntu Pro
+  'Ubuntu server' : Ubuntu Server
+  

--- a/test/test004.md
+++ b/test/test004.md
@@ -6,7 +6,7 @@ product name mistakes
 It's Anbox Cloud, not Anbox cloud or AnBox.
 We say Charmed Kubeflow not Charmed kubeflow.
 The Canonical Observability Stack is called COS and is not
-a Canononical observability stack.
+a Canonical observability stack.
 Juju, never JuJu, nor juju when not referring to the command.
 Landscape and Launchpad, not LandScape or LaunchPad.
 If you say lxd it should be in backticks `lxd`.
@@ -20,5 +20,5 @@ Multipass, like in that film, not MultiPass.
 Snapcraft, not SnapCraft or snapcraft.
 snapd not snapD or SnapD or Snapd.
 Ubuntu Pro, not Ubuntu pro.
-Ubuntu Server, though i guess people may talk about *an*
-Ubuntu server, but that should prompt a query.                         |
+Ubuntu Server, though I guess people may talk about *an*
+Ubuntu server, but that should prompt a query.                         

--- a/test/test004.md
+++ b/test/test004.md
@@ -1,0 +1,24 @@
+# Canonical product names
+
+This file should generate 25 suggestions for common
+product name mistakes
+
+It's Anbox Cloud, not Anbox cloud or AnBox.
+We say Charmed Kubeflow not Charmed kubeflow.
+The Canonical Observability Stack is called COS and is not
+a Canononical observability stack.
+Juju, never JuJu, nor juju when not referring to the command.
+Landscape and Launchpad, not LandScape or LaunchPad.
+If you say lxd it should be in backticks `lxd`.
+For the love of all that is holy, MAAS, not Maas or MaaS.
+MicroCeph and MicroCloud, not Microceph or Microcloud.
+MicroK8s, not Microk8s.
+MicroOVN, not microOVN or MicroOvn.
+MicroStack is the name, not microstack or Microstack.
+Mir doesn't have a common misspelling.
+Multipass, like in that film, not MultiPass.
+Snapcraft, not SnapCraft or snapcraft.
+snapd not snapD or SnapD or Snapd.
+Ubuntu Pro, not Ubuntu pro.
+Ubuntu Server, though i guess people may talk about *an*
+Ubuntu server, but that should prompt a query.                         |

--- a/test/test004.md
+++ b/test/test004.md
@@ -7,7 +7,7 @@ It's Anbox Cloud, not Anbox cloud or AnBox.
 We say Charmed Kubeflow not Charmed kubeflow.
 The Canonical Observability Stack is called COS and is not
 a Canonical observability stack.
-Juju, never JuJu, nor juju when not referring to the command.
+Juju, never JuJu, nor juju when not referring to the command `juju`.
 Landscape and Launchpad, not LandScape or LaunchPad.
 If you say lxd it should be in backticks `lxd`.
 For the love of all that is holy, MAAS, not Maas or MaaS.


### PR DESCRIPTION
Canonical product name, implemented as suggestions for replacement from common errors.