### PR TITLE
DOCPR-373: rule no. 003 correct use of Ubuntu versions

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -83,6 +83,7 @@ Some examples of correct usage:
 - **Ubuntu 22.10**
 - **Ubuntu 23.04 (Lunar Lobster)** _(note case!)_
 - **Ubuntu 23.10 (Mantic)**
+- **Ubuntu 24.04 LTS (Noble Numbat)**
 
 This also follows on to more specific products, e.g.
 

--- a/styles/Canonical/003-Ubuntu-names-versions.yml
+++ b/styles/Canonical/003-Ubuntu-names-versions.yml
@@ -6,7 +6,10 @@ message: |
 link: https://docs.ubuntu.com/styleguide/en/#ubuntu
 nonword: true
 ignorecase: true
-scope: raw
+scope: 
+  - sentence
+  - heading
+  - table 
 level: suggestion
 tokens:
   # LTS releases should be followed by "LTS" suffix.
@@ -27,3 +30,5 @@ tokens:
   - 'Ubuntu 19\.04 \((?!(Disco|Disco Dingo)\))'
   - 'Ubuntu 18\.10 \((?!(Cosmic|Cosmic Cuttlefish)\))'
   - 'Ubuntu 18\.04 LTS \((?!(Bionic|Bionic Beaver)\))'  
+
+  

--- a/styles/Canonical/003-Ubuntu-names-versions.yml
+++ b/styles/Canonical/003-Ubuntu-names-versions.yml
@@ -1,0 +1,29 @@
+extends: existence
+message: |
+  Please use the Ubuntu product name correctly. E.g. Ubuntu 22.04 LTS, Ubuntu
+  22.10, Ubuntu 23.04 (Lunar Lobster), Ubuntu 23.10 (Mantic), Ubuntu 24.04 LTS
+  (Noble Numbat).
+link: https://docs.ubuntu.com/styleguide/en/#ubuntu
+nonword: true
+ignorecase: true
+scope: raw
+level: suggestion
+tokens:
+  # LTS releases should be followed by "LTS" suffix.
+  - 'Ubuntu (24|22|20|18)\.04(?! LTS)'
+  # Non-LTS releases should not be followed by "LTS" suffix.
+  - 'Ubuntu (23\.10|23\.04|22\.10|21\.10|21\.04|20\.10|19\.10|19\.04|18\.10|17\.10|17\.04) LTS'
+  # All releases should match the code name.
+  - 'Ubuntu 24\.04 LTS \((?!(Noble|Noble Numbat)\))'
+  - 'Ubuntu 23\.10 \((?!(Mantic|Mantic Minotaur)\))'
+  - 'Ubuntu 23\.04 \((?!(Lunar|Lunar Lobster)\))'
+  - 'Ubuntu 22\.10 \((?!(Kinetic|Kinetic Kudu)\))'
+  - 'Ubuntu 22\.04 LTS \((?!(Jammy|Jammy Jellyfish)\))'
+  - 'Ubuntu 21\.10 \((?!(Impish|Impish Indri)\))'
+  - 'Ubuntu 21\.04 \((?!(Hirsute|Hirsute Hippo)\))'
+  - 'Ubuntu 20\.10 \((?!(Groovy|Groovy Gorilla)\))'
+  - 'Ubuntu 20\.04 LTS \((?!(Focal|Focal Fossa)\))'
+  - 'Ubuntu 19\.10 \((?!(Eoan|Eoan Ermine)\))'
+  - 'Ubuntu 19\.04 \((?!(Disco|Disco Dingo)\))'
+  - 'Ubuntu 18\.10 \((?!(Cosmic|Cosmic Cuttlefish)\))'
+  - 'Ubuntu 18\.04 LTS \((?!(Bionic|Bionic Beaver)\))'  

--- a/test/test003.md
+++ b/test/test003.md
@@ -1,0 +1,24 @@
+This section contains positive test cases for rule #003.
+
+Ubuntu 24.04 LTS
+
+Ubuntu 24.04 LTS (Noble)
+
+Ubuntu 24.04 LTS (Noble Numbat)
+
+---
+
+This section contains negative test cases for rule #003.
+These negative test cases should return five suggestions.
+
+---
+
+Ubuntu 24.04 has been released
+
+Ubuntu 23.10 LTS is codenamed Mantic Minotaur
+
+Ubuntu 24.04 LTS (Numbat)
+
+How to download Ubuntu 22.04
+
+Installed version is Ubuntu 18.10 (Cuttlefish)

--- a/test/test003.md
+++ b/test/test003.md
@@ -1,4 +1,4 @@
-This section contains positive test cases for rule #003.
+# This section contains positive test cases for rule #003
 
 Ubuntu 24.04 LTS
 
@@ -6,10 +6,17 @@ Ubuntu 24.04 LTS (Noble)
 
 Ubuntu 24.04 LTS (Noble Numbat)
 
+## Ubuntu 24.04 LTS
+
+| Cycle  | OS                          |
+|--------|-----------------------------|
+| 22.04  | Ubuntu 22.04 LTS (Jammy)    |
+| 22.10  | Ubuntu 22.10 (Kinetic Kudu) |
+
 ---
 
 This section contains negative test cases for rule #003.
-These negative test cases should return five suggestions.
+These negative test cases should return eight suggestions.
 
 ---
 
@@ -22,3 +29,10 @@ Ubuntu 24.04 LTS (Numbat)
 How to download Ubuntu 22.04
 
 Installed version is Ubuntu 18.10 (Cuttlefish)
+
+## Ubuntu 23.10 LTS
+
+| Cycle  | OS                          |
+|--------|-----------------------------|
+| 22.04  | Ubuntu 22.04 LTS (Jimmy)    |
+| 22.04  | Ubuntu 22.04 (Kinetic Kudu) |


### PR DESCRIPTION
PR for DOCPR-373 to address rule no. 003, correct use of Ubuntu versions.
I don't have examples of what are common incorrect uses; hence am just making assumptions about the incorrect scenarios.

The list of releases are checked until 18.04 since the rest are historically very old versions already. This is due to the current regex definition which is not too flexible in terms of versions that are being detected (to be more accurate).

Also there is only 1 version of the test file (in MD) since for this rule, the syntax for RST vs MD is irrelevant.

Thanks.