### PR TITLE
Add Vale rule 14: Numeric format for numbers above nine and for numbers greater than 9999

### DIFF
--- a/styles/Canonical/014a-Numbers-greater-than-nine-should-be-in-numeric-form.yml
+++ b/styles/Canonical/014a-Numbers-greater-than-nine-should-be-in-numeric-form.yml
@@ -1,7 +1,12 @@
 extends: existence
 message: Write numbers greater than nine in numeric form - (%s)
 link: https://docs.ubuntu.com/styleguide/en#numbers
-scope: raw
+scope:
+  - heading
+  - list
+  - sentence
+  - table.header
+  - table.cell
 ignorecase: true
 level: warning
 tokens:

--- a/styles/Canonical/014a-Numbers-greater-than-nine-should-be-in-numeric-form.yml
+++ b/styles/Canonical/014a-Numbers-greater-than-nine-should-be-in-numeric-form.yml
@@ -1,0 +1,30 @@
+extends: existence
+message: Write numbers greater than nine in numeric form - (%s)
+link: https://docs.ubuntu.com/styleguide/en#numbers
+scope: raw
+ignorecase: true
+level: warning
+tokens:
+  - ten
+  - eleven
+  - twelve
+  - thirteen
+  - fourteen
+  - fifteen
+  - sixteen
+  - seventeen
+  - eighteen
+  - nineteen
+  - twenty
+  - thirty
+  - forty
+  - fifty
+  - sixty
+  - seventy
+  - eighty
+  - ninety
+  - hundred
+  - thousand
+  - million
+  - billion
+  - trillion

--- a/styles/Canonical/014b-Numbers-with-five-or-more-digits-must-have-comma-separators.yml
+++ b/styles/Canonical/014b-Numbers-with-five-or-more-digits-must-have-comma-separators.yml
@@ -10,4 +10,4 @@ scope:
 ignorecase: true
 level: warning
 tokens:
-  - ([\d]{4,})
+  - ([\d]{5,})

--- a/styles/Canonical/014b-Numbers-with-four-or-more-digits-must-have-comma-separators.yml
+++ b/styles/Canonical/014b-Numbers-with-four-or-more-digits-must-have-comma-separators.yml
@@ -1,0 +1,8 @@
+extends: existence
+message: Numbers greater than 999 should have a comma separator - '%s'
+link: https://docs.ubuntu.com/styleguide/en#numbers
+scope: raw
+ignorecase: true
+level: warning
+tokens:
+  - ([\d]{4,})

--- a/styles/Canonical/014b-Numbers-with-four-or-more-digits-must-have-comma-separators.yml
+++ b/styles/Canonical/014b-Numbers-with-four-or-more-digits-must-have-comma-separators.yml
@@ -1,7 +1,12 @@
 extends: existence
 message: Numbers greater than 999 should have a comma separator - '%s'
 link: https://docs.ubuntu.com/styleguide/en#numbers
-scope: raw
+scope:
+  - heading
+  - list
+  - sentence
+  - table.header
+  - table.cell
 ignorecase: true
 level: warning
 tokens:

--- a/test/test14.md
+++ b/test/test14.md
@@ -1,0 +1,31 @@
+# Testing Vale rule 14
+
+## Numbers greater than nine should be in numeric form
+
+Testing the following numbers:
+
+Ten
+Eleven
+Twelve
+Thirteen
+Fourteen
+Fifteen
+Nine hundred and sixteen
+Six thousand and seventeen
+Fifty thousand and five hundred
+Eighteen billion
+Ninety million
+Twenty trillion
+Seventy million eight thousand and one
+Sixty billion forty million thirty thousand and nineteen
+Five
+Nine
+
+## Numbers greater than 999 should have comma separators
+
+1000
+23400
+8767862
+90283737
+347874838
+1000000000

--- a/test/test14.md
+++ b/test/test14.md
@@ -34,8 +34,8 @@ Nine
 - Twenty
 - Five
 
-## Numbers greater than 999 should have comma separators
-<!--This test will produce 6 warnings-->
+## Numbers greater than 9999 should have comma separators
+<!--This test will produce 5 warnings-->
 
 1000
 23400

--- a/test/test14.md
+++ b/test/test14.md
@@ -1,8 +1,9 @@
 # Testing Vale rule 14
 
 ## Numbers greater than nine should be in numeric form
+<!--This test will produce 38 warnings-->
 
-Testing the following numbers:
+### Test heading to test the following sixteen numbers
 
 Ten
 Eleven
@@ -21,7 +22,20 @@ Sixty billion forty million thirty thousand and nineteen
 Five
 Nine
 
+### Test scope for tables
+
+| billion | ninety | fifty|
+|---------|---------|------|
+| hundred |thousand |twenty|
+
+### Test scope for list
+
+- Hundred
+- Twenty
+- Five
+
 ## Numbers greater than 999 should have comma separators
+<!--This test will produce 6 warnings-->
 
 1000
 23400
@@ -29,3 +43,6 @@ Nine
 90283737
 347874838
 1000000000
+3
+46
+345


### PR DESCRIPTION
@evilnick @SecondSkoll 
This is for [DOCPR-384](https://warthogs.atlassian.net/browse/DOCPR-384).

This rule was a bit more complicated than I expected and I had to break it down into two sub-rules:

- Numbers greater than nine should not be spelled out
- Numbers greater than 999 should have appropriate comma separators

It also got extremely complicated (or the rule being too long) when I tried to match all numbers greater than nine, so I have tried a simpler way. Hope this is fine!

[DOCPR-384]: https://warthogs.atlassian.net/browse/DOCPR-384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ