### PR TITLE
Add Canonical vocabulary

### DIFF
--- a/styles/config/vocabularies/Canonical/Accept.txt
+++ b/styles/config/vocabularies/Canonical/Accept.txt
@@ -1,0 +1,24 @@
+Anbox Cloud
+Charmed Kubeflow
+COS
+Juju
+Landscape
+Launchpad
+LXD
+MAAS
+MicroCeph
+MicroCloud
+MicroK8s
+MicroOVN
+MicroStack
+Mir
+Multipass
+Snapcraft
+snapd
+Ubuntu Core
+Ubuntu Pro
+Ubuntu Server
+NVIDIA
+OpenStack
+PostgreSQL
+Kubernetes

--- a/test/testvocab.md
+++ b/test/testvocab.md
@@ -1,0 +1,35 @@
+# snapd (should not be flagged)
+
+The heading above should not be flagged by the capitalization or spelling rules.
+
+# MASS (should not be flagged)
+
+The heading above should not be flagged by the capitalization or spelling rules.
+
+These product names should not be flagged:
+Anbox Cloud
+Charmed Kubeflow
+COS
+Juju
+Landscape
+Launchpad
+LXD
+MAAS
+MicroCeph
+MicroCloud
+MicroK8s
+MicroOVN
+MicroStack
+Mir
+Multipass
+Snapcraft
+snapd
+Ubuntu Core
+Ubuntu Pro
+Ubuntu Server
+NVIDIA
+OpenStack
+PostgreSQL
+Kubernetes
+
+

--- a/vale.ini
+++ b/vale.ini
@@ -3,7 +3,7 @@ MinAlertLevel = suggestion
 
 [*]
 
-BasedOnStyles = Canonical
+BasedOnStyles = Canonical, Vale
 
 Vocab = Canonical
 

--- a/vale.ini
+++ b/vale.ini
@@ -5,4 +5,6 @@ MinAlertLevel = suggestion
 
 BasedOnStyles = Canonical
 
+Vocab = Canonical
+
 IgnoredScopes = 


### PR DESCRIPTION
Adding a Canonical vocabulary that can be iteratively updated.

@evilnick I am a little blocked on this - when running testing on the test file, the capitalization rule is still triggered on the headings even though `Accept.txt` should work as a list of exceptions for any style rules. Am I missing something? Could you point me in the right direction? :thinking: 