### PR TITLE
Avoid inlining comments in code blocks

### DIFF
--- a/styles/Canonical/016-No-inline-comments.yml
+++ b/styles/Canonical/016-No-inline-comments.yml
@@ -1,0 +1,12 @@
+extends: existence
+message: "Avoid inline comments in code blocks."
+scope: raw
+nonword: true
+level: warning
+tokens:
+  - ^```.*(\n(?s:.)*#.*)+.*\n```
+  - ^```.*(\n(?s:.)*//.*)+.*\n```
+  - '\.\. code(-block)?:.*\n(\s+.*#.*\n)+'
+  - '\.\. code(-block)?:.*\n(\s+.*//.*\n)+'
+
+

--- a/test/test016.md
+++ b/test/test016.md
@@ -1,0 +1,20 @@
+This example should result in two warnings.
+
+# The heading should be ignored
+
+This line that contain # and // in the middle should also be ignored.
+
+```python
+# This line should be ignored
+print("Hello, world!")  # This line should be flagged
+```
+
+```python
+# This line should be ignored
+print("Hello, world!") 
+```
+
+```java
+// This line should be ignored
+System.out.println("Hello World"); // This line should be flagged
+```

--- a/test/test016.rst
+++ b/test/test016.rst
@@ -1,0 +1,21 @@
+This example should result in two warnings
+=======
+
+This line that contains :: in the middle should be ignored.
+
+
+.. code-block:: python
+
+    # This line should be ignored
+    print("Hello, world!")  # This line should be flagged
+
+Some more text.
+
+    # Another code block
+    int x = 5;  # This line should be flagged
+
+.. code:: c++
+
+    // This should be ignored
+    int main() { // This line should be flagged
+        return


### PR DESCRIPTION
Adds a rule that raises a warning every time it detects a code block (defined by ``` in MD and `code-block` in reST) and that contains a line with a codeblock (`#` and `//` as of now as the two popular ways to define a comment in many languages, the list can be expanded).

The rule will raise a false positive if `#` or `\\` that is not a comment occurs in the code block. The only example I can think of is Win path format e.g. `C:\\`. :thinking: 