### PR TITLE
DOCPR-663: add section on Diátaxis to the style guide

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -14,9 +14,9 @@ Diátaxis provides rules that help you identify the type of document that you ar
 Document types include:
 
 - Tutorial
-- How-to guides
-- Explanations
+- How-to guide
 - Reference
+- Explanation
 
 Each type serves a different user need — it is useful to understand the needs being addressed as these will influence the documentation approach. 
 

--- a/en/index.md
+++ b/en/index.md
@@ -18,7 +18,8 @@ Document types include:
 - Reference
 - Explanation
 
-Each type serves a different user need — it is useful to understand the needs being addressed as these will influence the documentation approach. 
+Each type serves a different user need — it is useful to understand the needs being
+addressed as these will influence the documentation approach. 
 
 Refer to the [official Diátaxis website](https://diataxis.fr/) for more information.
 

--- a/en/index.md
+++ b/en/index.md
@@ -9,15 +9,16 @@ to the left, and presented here as a single page to aid searching.
 
 ## Diátaxis
 
-Use Diátaxis to structure product documentation. A documentation page should
-fit within one of the following categories:
+Use Diátaxis to structure product documentation.
+Diátaxis provides rules that help you identify the type of document that you are writing.
+Types of document include:
 
 - Tutorial
-- How-to
-- Explanation
+- How-to guides
+- Explanations
 - Reference
 
-Each category serves a different user need - it is useful to understand the needs being addressed as these may influence the documentation approach. 
+Each type serves a different user need — it is useful to understand the needs being addressed as these will influence the documentation approach. 
 
 Refer to the [official Diátaxis website](https://diataxis.fr/) for more information.
 

--- a/en/index.md
+++ b/en/index.md
@@ -17,7 +17,7 @@ fit within one of the following categories:
 - Explanation
 - Reference
 
-Each category serves a different user need and is written in a specific style.
+Each category serves a different user need - it is useful to understand the needs being addressed as these may influence the documentation approach. 
 
 Refer to the [official Diátaxis website](https://diataxis.fr/) for more information.
 

--- a/en/index.md
+++ b/en/index.md
@@ -11,7 +11,7 @@ to the left, and presented here as a single page to aid searching.
 
 Use Diátaxis to structure product documentation.
 Diátaxis provides rules that help you identify the type of document that you are writing.
-Types of document include:
+Document types include:
 
 - Tutorial
 - How-to guides

--- a/en/index.md
+++ b/en/index.md
@@ -17,10 +17,7 @@ fit within one of the following categories:
 - Explanation
 - Reference
 
-The choice of category will have an influence on the style of writing.
-References should aim to be entirely factual, while explanations may include
-opinions and analogies. A good how-to will enable the completion of a task but
-a tutorial will also promote the acquisition of a skill.
+Each category serves a different user need and is written in a specific style.
 
 Refer to the [official Diátaxis website](https://diataxis.fr/) for more information.
 

--- a/en/index.md
+++ b/en/index.md
@@ -7,6 +7,23 @@ for Canonical documentation projects. Topics are listed in the navigation
 to the left, and presented here as a single page to aid searching.
 
 
+## Diátaxis
+
+Use Diátaxis to structure product documentation. A documentation page should
+fit within one of the following categories:
+
+- Tutorial
+- How-to
+- Explanation
+- Reference
+
+The choice of category will have an influence on the style of writing.
+References should aim to be entirely factual, while explanations may include
+opinions and analogies. A good how-to will enable the completion of a task but
+a tutorial will also promote the acquisition of a skill.
+
+Refer to the [official Diátaxis website](https://diataxis.fr/) for more information.
+
 ## Spelling
 
 Canonical is a UK based company, and uses British English throughout. There

--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -16,6 +16,8 @@ navigation:
 
     children:
 
+    - title: Diátaxis
+      location: '#diataxis'
     - title: Spelling
       location: '#spelling'
     - title: Branding


### PR DESCRIPTION
PR for [Jira ticket DOCPR-663](https://warthogs.atlassian.net/browse/DOCPR-663), which aims to include a brief reference to Diátaxis in the style guide.

Diátaxis is the foundation from which much of Canonical's product documentation is built. The form and style of a page of documentation is influenced by the Diátaxis category in which it fits.

Given its centrality, a reader might expect to find a reference to this framework in the style guide.

This PR adds a brief section on Diátaxis to the top of the style guide. It mentions briefly:

- That Diátaxis should be used
- The four categories in Diátaxis
- How the categories can influence style
- A link to a more detailed resource (the Diátaxis website)
