### PR TITLE
Add Backticks to 006-Contractions-forbidden.yml

### DIFF
--- a/styles/Canonical/006-Contractions-forbidden.yml
+++ b/styles/Canonical/006-Contractions-forbidden.yml
@@ -6,14 +6,14 @@ link: https://docs.ubuntu.com/styleguide/en#don't-use-these!
 level: warning
 ignorecase: true
 swap:
-  ain't: isn't
-  how'd: how did
-  how'll: how will
-  I'd: one would
-  something's: something is
-  mayn't: may not
-  may've: may have
-  mightn't: might not
-  might've: might have
+  ain[`']t: isn't
+  how[`']d: how did
+  how[`']ll: how will
+  I[`']d: one would
+  something[`']s: something is
+  mayn[`']t: may not
+  may[`']ve: may have
+  mightn[`']t: might not
+  might[`']ve: might have
   gonna: going to
   gotta: got to


### PR DESCRIPTION
For some reason, people often use backticks instead of apostrophes in contractions. I added them to the rule.