### PR TITLE
fix: diataxis anchor link

### DIFF
--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -17,7 +17,7 @@ navigation:
     children:
 
     - title: Diátaxis
-      location: '#diataxis'
+      location: '#diátaxis'
     - title: Spelling
       location: '#spelling'
     - title: Branding


### PR DESCRIPTION
This is a tiny fix to the anchor link generated for the Diátaxis section of the style guide.

Currently the `href` is `#diataxis`, which does not navigate to the section when clicked.
When changed to `#diátaxis` in the browser inspector the anchor link enables navigation as expected.

This PR changes the relevant location value in the `metadata.yaml`.