### PR TITLE
fix: use url-encoding for diataxis

### DIFF
--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -17,7 +17,7 @@ navigation:
     children:
 
     - title: Diátaxis
-      location: '#diátaxis'
+      location: '#di%C3%A1taxis'
     - title: Spelling
       location: '#spelling'
     - title: Branding


### PR DESCRIPTION
A [previous PR](https://github.com/canonical/praecepta/pull/47) attempted a naive fix for the problem of a non-functional  internal link to the new Diátaxis section, where an attempt was made to include the accented character in the url. This did not work.

In this PR, the accented character is replaced by a url-encoded version, with `á` replaced by `%C3%A1`. The resultant url worked during local testing but we need to check after the site is built.

If this fix doesn't work we might need to consider a simplified version of the section header itself or, alternatively, look into how the `metadata.yaml` is parsed.