### PR TITLE
Update 004-Canonical-product-names.yml

### DIFF
--- a/styles/Canonical/004-Canonical-product-names.yml
+++ b/styles/Canonical/004-Canonical-product-names.yml
@@ -7,22 +7,22 @@ action:
   name: replace
 swap:
   Anbox Cloud: Anbox Cloud
-  AnBox: Anbox
-  Charmed Kubeflow : Charmed Kubeflow
-  Canononical Observability Stack : Canonical Observability Stack
-  Juju : Juju
-  Landscape : Landscape
-  Launchpad : Launchpad
-  LXD : LXD
-  MAAS : MAAS
-  MicroCeph : MicroCeph
-  MicroCloud : MicroCloud
-  MicroK8s : MicroK8s
-  MicroOVN : MicroOVN
-  MicroStack : MicroStack
-  Multipass : Multipass
-  Snapcraft : Snapcraft
-  snapd : snapd
+  Anbox: Anbox
+  Charmed Kubeflow: Charmed Kubeflow
+  Canononical Observability Stack: Canonical Observability Stack
+  Juju: Juju
+  Landscape: Landscape
+  Launchpad: Launchpad
+  LXD: LXD
+  MAAS: MAAS
+  MicroCeph: MicroCeph
+  MicroCloud: MicroCloud
+  MicroK8s: MicroK8s
+  MicroOVN: MicroOVN
+  MicroStack: MicroStack
+  Multipass: Multipass
+  Snapcraft: Snapcraft
+  snapd: snapd
   Ubuntu Core: Ubuntu Core
-  Ubuntu Pro : Ubuntu Pro
-  Ubuntu Server : Ubuntu Server
+  Ubuntu Pro: Ubuntu Pro
+  Ubuntu Server: Ubuntu Server

--- a/styles/Canonical/004-Canonical-product-names.yml
+++ b/styles/Canonical/004-Canonical-product-names.yml
@@ -1,37 +1,28 @@
 extends: substitution
 message: "Use '%s' instead of '%s'"
 link: https://docs.ubuntu.com/styleguide/en/#other-canonical-products
-ignorecase: false
+ignorecase: true
 level: suggestion
 action:
   name: replace
 swap:
-  'Anbox cloud': Anbox Cloud
-  'AnBox': Anbox
-  'Charmed kubeflow' : Charmed Kubeflow
-  'Canononical observability stack' : Canonical Observability Stack
-  'juju' : Juju
-  'JuJu' : Juju
-  'LandScape' : Landscape
-  'LaunchPad' : Launchpad
-  'lxd' : LXD
-  'MaaS' : MAAS
-  'Maas' : MAAS
-  'maas' : MAAS
-  'Microceph' : MicroCeph
-  'Microcloud' : MicroCloud
-  'Microk8s' : MicroK8s
-  'Microovn' : MicroOVN
-  'MicroOvn' : MicroOVN
-  'Microstack' : MicroStack
-  'microstack': MicroStack
-  'MultiPass' : Multipass
-  'multipass' : Multipass
-  'SnapCraft' : Snapcraft
-  'snapcraft' : Snapcraft
-  'snapD' : snapd
-  'Snapd' : snapd
-  'SnapD' : snapd
-  'Ubuntu pro' : Ubuntu Pro
-  'Ubuntu server' : Ubuntu Server
-  
+  Anbox Cloud: Anbox Cloud
+  AnBox: Anbox
+  Charmed Kubeflow : Charmed Kubeflow
+  Canononical Observability Stack : Canonical Observability Stack
+  Juju : Juju
+  Landscape : Landscape
+  Launchpad : Launchpad
+  LXD : LXD
+  MAAS : MAAS
+  MicroCeph : MicroCeph
+  MicroCloud : MicroCloud
+  MicroK8s : MicroK8s
+  MicroOVN : MicroOVN
+  MicroStack : MicroStack
+  Multipass : Multipass
+  Snapcraft : Snapcraft
+  snapd : snapd
+  Ubuntu Core: Ubuntu Core
+  Ubuntu Pro : Ubuntu Pro
+  Ubuntu Server : Ubuntu Server


### PR DESCRIPTION
I tried to improve the rule and easier to read by converting it to an ``ignorecase: true`` rule.

Below, I've quoted my [comment](https://github.com/canonical/praecepta/pull/60#discussion_r1673454996) on the other pull request to explain the utility:

> You may want to consider `ignorecase: true` instead.
> 
> To explain why, let's review what the rule does with `nVidia: NVIDIA`.
> 
> If the ignorecase is false:
> 
> * `NVidia` or `nvidia`, both common mistakes, will be ignored since they don't exactly match
> 
> If the ignorecase is true:
> 
> * All versions of `NVIDIA` that aren't written precisely in that manner will be corrected to it.
> 
> You could even change the rule to `NVIDIA: NVIDIA` and the result with `ignorecase: true` would be the same. All incorrect capitalizations would be fixed but `NVIDIA` would not trigger an error.

I also added ``Ubuntu Core`` to the rules.