### PR TITLE
DOCPR-664: add section on video to style guide

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -372,6 +372,20 @@ An image should not be overly cropped - allow for context.
 **DO NOT LINK IMAGES FROM A GOOGLE DRIVE**
 This will work, until such a time as whoever owns the image closes their account (or leaves Canonical).
 
+## Video
+
+Video is rarely an effective replacement for text in product documentation.
+The use of videos in documentation is generally not recommended, as they are:
+
+- Challenging to do well
+- Difficult to maintain
+- Prone to accessibility issues
+
+When there is a legitimate need for video content within documentation, a tool like [asciinema](https://asciinema.org/) is preferred.
+This generates text-based videos that are easier to maintain, while the text itself can be copied/pasted by the person reading the documentation.
+
+Any videos which are included should meet the same standards of accuracy, clarity and quality expected of written documentation.
+
 <!-- RULE
 #20 Cliché words and phrases to avoid
 -->

--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -34,6 +34,8 @@ navigation:
       location: '#code-examples-in-documentation'
     - title: Images
       location: '#images'
+    - title: Video
+      location: '#video'
     - title: Words and phrases to avoid
       location: '#words-and-phrases-to-avoid'
     - title: Admonitions


### PR DESCRIPTION
PR for Jira ticket DOCPR-664, which aims to include a brief reference to Video in the style guide.

Videos are occasionally included in our documentation and are used prominently as a means of documentation elsewhere, so we should offer some guidance.

This proposal briefly refers to some of the difficulties of including videos, without going into their many complexities.

It also attempts to reflect some best practice that is currently implemented at Canonical, such as text-based video, and reiterates that if video is used as a form of documentation then it should meet certain standards.