### PR TITLE
Rule15: Prompts in codeblocks

### DIFF
--- a/styles/Canonical/015-No-prompts-in-comments.yml
+++ b/styles/Canonical/015-No-prompts-in-comments.yml
@@ -1,11 +1,7 @@
 extends: existence
-message: "Avoid using prompts in code blocks."
+message: "Avoid using prompts in code blocks: %s"
 scope: raw
 nonword: true
 level: warning
 tokens:
-  - '(?s)```.*?\n(?:^(?!```)[^\n]*\n)*?^(#[\$%>].*)\n(?:^(?!```)[^\n]*\n)*?```'
-  # - ^```.*\n(([^\n`][^\n#]*\n|\n))*([^\n#]+#.*\n)+([^\n`]*\n)*```
-  # - ^```.*\n([^\n`][^\n]*\n|\n)*([^\n\/][^\n\/]+\/\/.*\n)+([^\n`]*\n)*```
-  # - '\.\. code(-block)?:.*\n(\s+.*#.*\n)+'
-  # - '\.\. code(-block)?:.*\n(\s+.*//.*\n)+'
+  - '^[ \t]*[$%]'

--- a/styles/Canonical/015-No-prompts-in-comments.yml
+++ b/styles/Canonical/015-No-prompts-in-comments.yml
@@ -1,0 +1,11 @@
+extends: existence
+message: "Avoid using prompts in code blocks."
+scope: raw
+nonword: true
+level: warning
+tokens:
+  - '(?s)```.*?\n(?:^(?!```)[^\n]*\n)*?^(#[\$%>].*)\n(?:^(?!```)[^\n]*\n)*?```'
+  # - ^```.*\n(([^\n`][^\n#]*\n|\n))*([^\n#]+#.*\n)+([^\n`]*\n)*```
+  # - ^```.*\n([^\n`][^\n]*\n|\n)*([^\n\/][^\n\/]+\/\/.*\n)+([^\n`]*\n)*```
+  # - '\.\. code(-block)?:.*\n(\s+.*#.*\n)+'
+  # - '\.\. code(-block)?:.*\n(\s+.*//.*\n)+'

--- a/test/test015.md
+++ b/test/test015.md
@@ -5,15 +5,16 @@ This example should result in two warnings.
 This line that contain # and // in the middle should also be ignored.
 
 ```python
-# This line should be flagged
-print("Hello, world!")  # This line should be ignored
+# These lines should be ignored
+print("Hello, world!")
 ```
 
 ```
+print("Hello, world!")
+//This line should be ignored
  # This line should be ignored
 $> This line should be flagged
 % > This line should be flagged
-print("Hello, world!") // This line should be ignored
 ```
 
 > This line should be ignored

--- a/test/test015.md
+++ b/test/test015.md
@@ -1,0 +1,19 @@
+This example should result in two warnings.
+
+# The heading should be ignored
+
+This line that contain # and // in the middle should also be ignored.
+
+```python
+# This line should be flagged
+print("Hello, world!")  # This line should be ignored
+```
+
+```
+ # This line should be ignored
+$> This line should be flagged
+% > This line should be flagged
+print("Hello, world!") // This line should be ignored
+```
+
+> This line should be ignored

--- a/test/test015.rst
+++ b/test/test015.rst
@@ -3,21 +3,8 @@ This example should result in two warnings
 
 This line that contains :: in the middle should be ignored.
 
-
 .. code-block:: python
-
-    # This line should be flagged
+    print("Hello, world!")
+    # This line should be ignored
     $ This line should be flagged
     %> This line should be flagged
-    print("Hello, world!")  # This line should be ignored
-
-Some more text.
-
-    # Another code block
-    int x = 5;  # This line should be flagged
-
-.. code:: c++
-
-    // This should be ignored
-    int main() { // This line should be ignored
-        return

--- a/test/test015.rst
+++ b/test/test015.rst
@@ -1,0 +1,23 @@
+This example should result in two warnings
+=======
+
+This line that contains :: in the middle should be ignored.
+
+
+.. code-block:: python
+
+    # This line should be flagged
+    $ This line should be flagged
+    %> This line should be flagged
+    print("Hello, world!")  # This line should be ignored
+
+Some more text.
+
+    # Another code block
+    int x = 5;  # This line should be flagged
+
+.. code:: c++
+
+    // This should be ignored
+    int main() { // This line should be ignored
+        return


### PR DESCRIPTION
Implement the Rule # 15: No prompts in code blocks 

After multiple attempts to make it work with sophisticated RegEx (that matched every code block first) I've reduced the regex to detect the specific symbols used for CLI prompts used at the very beginning of a line.

That solution works great for its simple implementation: it gets the job done with no false positives detected so far.