### PR TITLE
Add placeholder advice

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -375,7 +375,9 @@ lxc delete <instance_name>/<snapshot_name>
 
 Here, the reader is expected to substitute their values for the placeholders.
 To minimise the risk of errors, instruct the reader that such values need to be
-substituted, especially when the first placeholder is referenced.
+substituted, especially when the first placeholder is referenced. There is no
+set style for the delimiter: the author should choose something unlikely to be
+confusing in the context, and use it consistently.
 
 However, in longer code blocks the placeholders become more difficult to manage
 and easier to overlook. Instead, consider defining the placeholders as

--- a/en/index.md
+++ b/en/index.md
@@ -364,9 +364,10 @@ state of each unit and service:
 
 ### Placeholders in code blocks
 
-There are many situations where it's necessary for users to provide their own information in a code block, such as IP addresses or
-names. It's common to substitute these values with a placeholder, where the
-placeholder represents the value that should be replaced. For example:
+There are many situations where it's necessary for users to provide their own
+information in a code block, such as IP addresses or names. It's common to
+substitute these values with a placeholder, consisting of terms within
+delimiters, representing the value to be replaced. For example:
 
 ```
 lxc delete <instance_name>/<snapshot_name>
@@ -376,14 +377,13 @@ Here, the reader is expected to substitute their values for the placeholders.
 To minimise the risk of errors, instruct the reader that such values need to be
 substituted, especially when the first placeholder is referenced.
 
-This approach is in common use and is effective for short commands, but is less
-suitable for a long block of code where the user then has to edit a multi-line
-command and search through to find the placeholders to replace. A useful
-approach in these circumstances is to adjust the code to define user-supplied
-data as environmental variables. For example:
+However, in longer code blocks the placeholders become more difficult to manage
+and easier to overlook. Instead, consider defining the placeholders as
+environmental variables. For example:
 
 ````
-Set the desired channel:
+Define the channel for the charms required. For example, to select the stable 
+release of 1.30:
 
 ```
 CHANNEL=1.30/stable
@@ -401,7 +401,8 @@ juju download kubernetes-worker --channel=$CHANNEL
 
 This approach has the following advantages:
 
- - Separates user-supplied data from commands, making it easier to reference and explain
+ - Separates user-supplied data from commands, making it easier to reference
+   and explain
  - Enables blocks of code to be copied without modification
  - Reduces the chance of users making mistakes when editing the commands
 

--- a/en/index.md
+++ b/en/index.md
@@ -364,8 +364,7 @@ state of each unit and service:
 
 ### Placeholders in code blocks
 
-There are many times when it will be necessary for the user to supply terms or
-data to a command which cannot be known in advance, for example IP addresses or
+There are many situations where it's necessary for users to provide their own information in a code block, such as IP addresses or
 names. It is common to substitute such values with a placeholder, where the
 placeholder consists of delimiters that contain terms that suggest the
 necessary input. For example:

--- a/en/index.md
+++ b/en/index.md
@@ -379,7 +379,7 @@ substituted, especially when the first placeholder is referenced. There is no
 set style for the delimiter: the author should choose something unlikely to be
 confusing in the context, and use it consistently.
 
-However, in longer code blocks the placeholders become more difficult to manage
+In longer code blocks the placeholders become more difficult to manage
 and easier to overlook. Instead, consider defining the placeholders as
 environmental variables. For example:
 

--- a/en/index.md
+++ b/en/index.md
@@ -401,7 +401,7 @@ juju download kubernetes-worker --channel=$CHANNEL
 
 ````
 
-This has the following advantages:
+This approach has the following advantages:
 
  - Separates user-supplied data from commands, making it easier to reference and explain
  - Enables blocks of code to be copied without modification

--- a/en/index.md
+++ b/en/index.md
@@ -19,7 +19,7 @@ Document types include:
 - Explanation
 
 Each type serves a different user need — it is useful to understand the needs being
-addressed as these will influence the documentation approach. 
+addressed as these will influence the documentation approach.
 
 Refer to the [official Diátaxis website](https://diataxis.fr/) for more information.
 
@@ -361,6 +361,51 @@ state of each unit and service:
 ...
 ...
 ```
+
+### Placeholders in code blocks
+
+There are many times when it will be necessary for the user to supply terms or
+data to a command which cannot be known in advance, for example IP addresses or
+names. It is common to substitute such values with a placeholder, where the
+placeholder consists of delimiters that contain terms that suggest the
+necessary input. For example:
+
+```
+lxc delete <instance_name>/<snapshot_name>
+```
+
+Here, the reader is expected to substitute their values for the placeholders.
+To minimise the risk of errors, instruct the reader that such values need to be
+substituted, especially when the first placeholder is referenced.
+
+This approach is in common use and is effective for short commands, but is less
+suitable for a long block of code where the user then has to edit a multi-line
+command and search through to find the placeholders to replace. A useful
+approach in these circumstances is to adjust the code to define user-supplied
+data as environmental variables. For example:
+
+````
+Set the desired channel:
+
+```
+CHANNEL=1.30/stable
+```
+
+Then proceed to fetch the required charms:
+
+```
+juju download easyrsa --channel=$CHANNEL
+juju download kubernetes-worker --channel=$CHANNEL
+...
+```
+
+````
+
+This has the following advantages:
+
+ - Separates user-supplied data from commands, making it easier to reference and explain
+ - Enables blocks of code to be copied without modification
+ - Reduces the chance of users making mistakes when editing the commands
 
 ## Images
 

--- a/en/index.md
+++ b/en/index.md
@@ -365,9 +365,8 @@ state of each unit and service:
 ### Placeholders in code blocks
 
 There are many situations where it's necessary for users to provide their own information in a code block, such as IP addresses or
-names. It is common to substitute such values with a placeholder, where the
-placeholder consists of delimiters that contain terms that suggest the
-necessary input. For example:
+names. It's common to substitute these values with a placeholder, where the
+placeholder represents the value that should be replaced. For example:
 
 ```
 lxc delete <instance_name>/<snapshot_name>


### PR DESCRIPTION
Add some futrher text advising on the use of placeholders in text.

This doesn't need to be added to navigation as it is a subset of the Code section.