### PR TITLE
Add inclusive language rule

### DIFF
--- a/styles/Canonical/400-Enforce-inclusive-terms.yml
+++ b/styles/Canonical/400-Enforce-inclusive-terms.yml
@@ -1,0 +1,23 @@
+extends: existence
+message: "Replace '%s' with an inclusive term"
+level: error
+ignorecase: true
+tokens:
+  - white(\-)?list(ed|ing)?
+  - black(\-)?list(ed|ing)?
+  - black( )?hats?
+  - white( )?hats?
+  - illegal characters?
+  - masters?
+  - slaves?
+  - chairman
+  - foreman
+  - dumm(y|ies)
+  - grandfather(ed)?
+  - guys?
+  - hangs?
+  - man hours?
+  - man( |-)in( |-)the( |-)middle
+  - manned
+  - middleman
+  - sanity check


### PR DESCRIPTION
Adds a rule that replaces the [terms currently captured by the woke checker](https://github.com/canonical/Inclusive-naming/blob/main/config.yml).