### PR TITLE
ubuntu-names-versions: Simplify LTS matching regexes

### DIFF
--- a/styles/Canonical/003-Ubuntu-names-versions.yml
+++ b/styles/Canonical/003-Ubuntu-names-versions.yml
@@ -13,11 +13,11 @@ scope:
 level: suggestion
 tokens:
   # LTS releases should be followed by "LTS" suffix.
-  - 'Ubuntu (24|22|20|18|16|14|12|10|8)\.04(?! LTS)'
+  - 'Ubuntu (\d)?(0|2|4|6|8)\.04(?! LTS)'
   - 'Ubuntu 6\.06(?! LTS)'
   # Non-LTS releases should not be followed by "LTS" suffix.
-  - 'Ubuntu (23|22|21|20|19|18|17|16|15|14|13|12|11|10|9|8|7|6\5\4)\.10 LTS'
-  - 'Ubuntu (23|21|19|17|15|13|11|10|9|8|7|5)\.04 LTS'
+  - 'Ubuntu [\d]{1,2}\.10 LTS'
+  - 'Ubuntu (\d)?(1|3|5|7|9)\.04 LTS'
   - 'Ubuntu 6\.06 LTS'
   # All releases should match the code name.
   - 'Ubuntu 24\.10 \((?!(Oracular|Oracular Oriole)\))'

--- a/styles/Canonical/003-Ubuntu-names-versions.yml
+++ b/styles/Canonical/003-Ubuntu-names-versions.yml
@@ -13,7 +13,7 @@ scope:
 level: suggestion
 tokens:
   # LTS releases should be followed by "LTS" suffix.
-  - 'Ubuntu (\d)?(0|2|4|6|8)\.04(?! LTS)'
+  - 'Ubuntu \d?[02468]\.04(?! LTS)'
   - 'Ubuntu 6\.06(?! LTS)'
   # Non-LTS releases should not be followed by "LTS" suffix.
   - 'Ubuntu \d?\d\.10 LTS'

--- a/styles/Canonical/003-Ubuntu-names-versions.yml
+++ b/styles/Canonical/003-Ubuntu-names-versions.yml
@@ -17,7 +17,7 @@ tokens:
   - 'Ubuntu 6\.06(?! LTS)'
   # Non-LTS releases should not be followed by "LTS" suffix.
   - 'Ubuntu [\d]{1,2}\.10 LTS'
-  - 'Ubuntu (\d)?(1|3|5|7|9)\.04 LTS'
+  - 'Ubuntu \d?[13579]\.04 LTS'
   - 'Ubuntu 6\.06 LTS'
   # All releases should match the code name.
   - 'Ubuntu 24\.10 \((?!(Oracular|Oracular Oriole)\))'

--- a/styles/Canonical/003-Ubuntu-names-versions.yml
+++ b/styles/Canonical/003-Ubuntu-names-versions.yml
@@ -16,7 +16,7 @@ tokens:
   - 'Ubuntu (\d)?(0|2|4|6|8)\.04(?! LTS)'
   - 'Ubuntu 6\.06(?! LTS)'
   # Non-LTS releases should not be followed by "LTS" suffix.
-  - 'Ubuntu [\d]{1,2}\.10 LTS'
+  - 'Ubuntu \d?\d\.10 LTS'
   - 'Ubuntu \d?[13579]\.04 LTS'
   - 'Ubuntu 6\.06 LTS'
   # All releases should match the code name.


### PR DESCRIPTION
LTS version names are so far predictable, so we can just error or accept versions happening on even years followed by 04 LTS, without maintaining a full list