### PR TITLE
Fix issue #66: Rule 11 - Stacked headings: False positives

### DIFF
--- a/styles/Canonical/011-Headings-not-followed-by-heading.yml
+++ b/styles/Canonical/011-Headings-not-followed-by-heading.yml
@@ -5,6 +5,6 @@ scope: raw
 level: error
 tokens:
   # Regex for Markdown.
-  - '(?m)^#{1,5}\s[^\n]*\n(\s*\n\s*)*^#{1,5}\s[^\n]*$'
+  - '(?m)^#{1,5}\s[^\n]*\n(\s*\n\s*)*^#{2,5}\s[^\n]*$'
   # Regex for reStructuredText.
-  - '(?m)^[^\n]+(\n[-=~^.]+)\n(\s*\n\s*)*^[^\n]+(\n[-=~^.]+)$'
+  - '(?m)^[^\n]+(\n([-=~^.])\2{3,})\n(\s*\n\s*)*^[^\n]+(\n([-=~^.])\5{3,})$'


### PR DESCRIPTION
Fix false positives when using three dots in markdown (MyST). 
Three dots triggered the RegEx for RST headings: multiple similar characters in a row.
Changed the RegEx to match cases only of more than 3 characters.

Fix the case of using more than one single-line comment in a code block (more than one line starts with a single # sign).