### PR TITLE
add itemised config

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,5 +111,5 @@ vale docs/test.md
 
 ### Customising the rules
 
-The published Vale Github action ignores suggestions and turns off some features which are likely to cause a lot of noise if run in their default state. A lot of things boil down to spellings. For example, the rule which checks for sentence case in headings doesn't know that SATA is an initialism by default, so if you include it, completely reasonably, in a heading it will be marked as an error. You may wish to turn this back on **if** you have a fairly complete vocabulary list.
+The published Vale GitHub action ignores suggestions and turns off some features which are likely to cause a lot of noise if run in their default state. A lot of things boil down to spellings. For example, the rule which checks for sentence case in headings doesn't know that SATA is an initialism by default, so if you include it, completely reasonably, in a heading it will be marked as an error. You may wish to turn this back on **if** you have a fairly complete vocabulary list.
 The example `vale.ini` file enumerates all the current rules and explicitly sets their error levels. This makes it simple to turn rules on or off, or add the spelling options, by simply making a copy of this file, editing it and including it in the repository where the checks are run. 

--- a/README.md
+++ b/README.md
@@ -108,3 +108,8 @@ vale docs
 vale docs/*.md
 vale docs/test.md
 ```
+
+### Customising the rules
+
+The published Vale Github action ignores suggestions and turns off some features which are likely to cause a lot of noise if run in their default state. A lot of things boil down to spellings. For example, the rule which checks for sentence case in headings doesn't know that SATA is an initialism by default, so if you include it, completely reasonably, in a heading it will be marked as an error. You may wish to turn this back on **if** you have a fairly complete vocabluary list.
+The example `vale.ini` file enumerates all the current rules and explicitly sets their error levels. This makes it simple to turn rules on or off, or add the spelling options, by simply making a copy of this file, editing it and including it in the repository where the checks are run. 

--- a/README.md
+++ b/README.md
@@ -111,5 +111,5 @@ vale docs/test.md
 
 ### Customising the rules
 
-The published Vale Github action ignores suggestions and turns off some features which are likely to cause a lot of noise if run in their default state. A lot of things boil down to spellings. For example, the rule which checks for sentence case in headings doesn't know that SATA is an initialism by default, so if you include it, completely reasonably, in a heading it will be marked as an error. You may wish to turn this back on **if** you have a fairly complete vocabluary list.
+The published Vale Github action ignores suggestions and turns off some features which are likely to cause a lot of noise if run in their default state. A lot of things boil down to spellings. For example, the rule which checks for sentence case in headings doesn't know that SATA is an initialism by default, so if you include it, completely reasonably, in a heading it will be marked as an error. You may wish to turn this back on **if** you have a fairly complete vocabulary list.
 The example `vale.ini` file enumerates all the current rules and explicitly sets their error levels. This makes it simple to turn rules on or off, or add the spelling options, by simply making a copy of this file, editing it and including it in the repository where the checks are run. 

--- a/vale.ini
+++ b/vale.ini
@@ -1,8 +1,34 @@
 StylesPath = styles
-MinAlertLevel = suggestion
+MinAlertLevel = warning
 Vocab = Canonical
 IgnoredScopes = 
 
 [*.{md,txt,rst,html}]
 
-BasedOnStyles = Canonical, Vale
+BasedOnStyles = Canonical
+
+# this enumerates all of the current rules with their suggested
+# severity level. This makes it easier to edit for specific use cases
+
+Canonical.001-English-words-spelling-suggestions  = suggest
+Canonical.003-Ubuntu-names-versions = warning              
+Canonical.004-Canonical-product-names = warning           
+Canonical.005-Industry-product-names = warning             
+Canonical.006-Contractions-forbidden = warning             
+Canonical.007-Headings-sentence-case = suggest           
+Canonical.008-Headings-no-period = warning               
+Canonical.009-Headings-no-links = error                
+Canonical.010-Punctuation-double-spaces = warning         
+Canonical.011-Headings-not-followed-by-heading = warning 
+Canonical.013-Spell-out-numbers-below-10 = suggest                                   
+Canonical.014a-Numbers-greater-than-nine-should-be-in-numeric-form = suggest         
+Canonical.014b-Numbers-with-five-or-more-digits-must-have-comma-separators  = suggest
+Canonical.016-No-inline-comments = warning
+Canonical.017-Avoid-long-code-blocks = warning
+Canonical.019-no-google-drive-images = error
+Canonical.020-Cliche-words-and-phrases = suggest
+Canonical.025a-latinisms-with-english-equivalents = suggest
+Canonical.025b-latinisms-to-reconsider = suggest
+Canonical.025c-latinisms-to-avoid = warning
+Canonical.400-Enforce-inclusive-terms = error
+Canonical.500-Repeated-words = NO


### PR DESCRIPTION
This PR:

- adds a low-noise default config, which explicitly sets each of the rules
- adds a section to the readme to explain this.

The rationale here is that we can use these defaults for a low-effort action anyone can use. This will not generate too much noise and cause them to turn it off, hopefully.
It also gives them an easy route to customise their config, because it is more evident what's going on.
We can update the config to target more rules when they give fewer false positives. The main impediment here is that we really need a very good/extensive accept.txt file that is likely to give good coverage for all products.