### PR TITLE
set four rules to error, and moved one from error to warning

### DIFF
--- a/styles/Canonical/003-Ubuntu-names-versions.yml
+++ b/styles/Canonical/003-Ubuntu-names-versions.yml
@@ -10,7 +10,7 @@ scope:
   - sentence
   - heading
   - table 
-level: suggestion
+level: error
 tokens:
   # LTS releases should be followed by "LTS" suffix.
   - 'Ubuntu (24|22|20|18|16|14|12|10|8)\.04(?! LTS)'

--- a/styles/Canonical/004-Canonical-product-names.yml
+++ b/styles/Canonical/004-Canonical-product-names.yml
@@ -2,7 +2,7 @@ extends: substitution
 message: "Use '%s' instead of '%s'"
 link: https://docs.ubuntu.com/styleguide/en/#other-canonical-products
 ignorecase: true
-level: suggestion
+level: error
 action:
   name: replace
 swap:

--- a/styles/Canonical/005-Industry-product-names.yml
+++ b/styles/Canonical/005-Industry-product-names.yml
@@ -2,7 +2,7 @@ extends: substitution
 message: "Use '%s' instead of '%s'"
 link: https://docs.ubuntu.com/styleguide/en/#other-commonly-referenced-products/projects
 ignorecase: true
-level: suggestion
+level: error
 action:
   name: replace
 swap:

--- a/styles/Canonical/007-Headings-sentence-case.yml
+++ b/styles/Canonical/007-Headings-sentence-case.yml
@@ -2,7 +2,7 @@ extends: capitalization
 # Fork of Google style guide rule
 message: "'%s' should use sentence-style capitalisation."
 link: "https://docs.ubuntu.com/styleguide/en/#sentence-case"
-level: warning
+level: error
 scope: heading
 match: $sentence
 exceptions:

--- a/styles/Canonical/011-Headings-not-followed-by-heading.yml
+++ b/styles/Canonical/011-Headings-not-followed-by-heading.yml
@@ -2,7 +2,7 @@ extends: existence
 message: "Avoid stacked headings. There should be content for each heading."
 nonword: true
 scope: raw
-level: error
+level: warning
 tokens:
   # Regex for Markdown.
   - '(?m)^#{1,5}\s[^\n]*\n(\s*\n\s*)*^#{2,5}\s[^\n]*$'


### PR DESCRIPTION
change three rules to error (blocking git actions) where legal and trademark issues may ensue; changed one rule to error where corporate communication standards would be violated; downgraded one rule (empty headings) to warning, since it is occasionally appropriate to do this.  this should represent the minimum blocking set we should require.