### PR TITLE
Change US spellcheck to 'warning'

### DIFF
--- a/vale.ini
+++ b/vale.ini
@@ -11,7 +11,7 @@ BasedOnStyles = Canonical
 # this enumerates all of the current rules with their suggested
 # severity level. This makes it easier to edit for specific use cases
 
-Canonical.000-US-spellcheck = error
+Canonical.000-US-spellcheck = warning
 Canonical.001-English-words-spelling-suggestions  = suggest
 Canonical.003-Ubuntu-names-versions = error              
 Canonical.004-Canonical-product-names = error           


### PR DESCRIPTION
Error level causes lots of fails that come without a heads up. Let's keep it at warning level for some transition period.