### PR TITLE
New US spelling: virtualisation → virtualization

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -72,7 +72,7 @@ technology terms:
  - website
  - internet
  - systems management
- - virtualisation
+ - virtualization
  - space-separated, comma-delimited
  - load balancer (only upper case as part of proper name e.g. Elastic Load Balancer)
 


### PR DESCRIPTION
The index page still recommends the UK "virtualisation" spelling. I'm updating it to the US "virtualization" spelling that we're using now.