### PR TITLE
add reST-only ignore list for spelling checks

### DIFF
--- a/vale.ini
+++ b/vale.ini
@@ -41,7 +41,7 @@ Canonical.500-Repeated-words = NO
 BasedOnStyles = Canonical
 
 # inline literal roles
-TokenIgnores = :relatedlinks:, ``.+?``, :samp:`.+?`, :file:`.+?`, :command:`.+?`
+TokenIgnores = :relatedlinks:, ``.+?``, :samp:`.+?`, :file:`.+?`, :command:`.+?`, :doc:`.+?`
 TokenIgnores = :program:`.+?`, :literal:`.+?`, :kbd:`.+?`, :file:`.+?`, :math:`.+?`
 TokenIgnores = :token:`.+?`, :regexp:`.+?`, :command:`.+?`, :option:`.+?`, :envvar:`.+?`
 

--- a/vale.ini
+++ b/vale.ini
@@ -36,3 +36,14 @@ Canonical.025b-latinisms-to-reconsider = suggest
 Canonical.025c-latinisms-to-avoid = warning
 Canonical.400-Enforce-inclusive-terms = error
 Canonical.500-Repeated-words = NO
+
+[*.rst]
+BasedOnStyles = Canonical
+
+# inline literal roles
+TokenIgnores = :relatedlinks:, ``.+?``, :samp:`.+?`, :file:`.+?`, :command:`.+?`
+TokenIgnores = :program:`.+?`, :literal:`.+?`, :kbd:`.+?`, :file:`.+?`, :math:`.+?`
+TokenIgnores = :token:`.+?`, :regexp:`.+?`, :command:`.+?`, :option:`.+?`, :envvar:`.+?`
+
+# links defined elsewhere
+TokenIgnores = \`\w+\`_


### PR DESCRIPTION
I briefly considered adding this machinery to the spelling rule in `000-US-spellcheck.yml` but quickly realized I don't know a good way to do that.