### PR TITLE
fix: rule 17 catastrophic backtracking

### DIFF
--- a/styles/Canonical/017-Avoid-long-code-blocks.yml
+++ b/styles/Canonical/017-Avoid-long-code-blocks.yml
@@ -7,6 +7,5 @@ nonword: true
 tokens:
   - '``` {0,1}({(code-block|code|sourcecode)}){0,1}[^{}\n]*\n(:[^\n]+:[^\n]*\n)*([^:\n]*\n){40,}```'
   - '::: {0,1}({(code-block|code|sourcecode)}){0,1}[^{}\n]*\n(:[^\n]+:[^\n]*\n)*([^:\n]*\n){40,}:::'
-  - '::\n\n( {3,12}[^\n]+\n){40,}'
-  - '\.\. (code-block|code|sourcecode)::\n( {3,12}:[^\n:]*:[^\n]*\n)*\n{0,1}( {3,60}[^\n]*\n){40,}'
-  
+  - '::\n\n( {3}[^\n]+\n){40,}'
+  - '\.\. (code-block|code|sourcecode)::\n( {3,12}:[^\n:]*:[^\n]*\n)*\n{0,1}(( {3}[^\n]+)?\n){40,}'


### PR DESCRIPTION
@rkratky found some strangeness with the Subiquity docs that caused Vale to hang. I narrowed it down to a specific document hanging on rule 17. Issue came about from the code block having many spaces in a line with text, this was caused by a backtracking error due to the nested, insufficiently bound quantifiers.

This does mean that some parameters may be caught as code block lines, but it does fix the main issue for now.