### PR TITLE
feat: scopes all rules and adds functional token ignores for RST

### DIFF
--- a/styles/Canonical/000-US-spellcheck.yml
+++ b/styles/Canonical/000-US-spellcheck.yml
@@ -2,6 +2,8 @@
 extends: spelling
 message: "The word '%s' seems to be misspelled."
 level: error
+scope:
+  - summary
 dicpath: "config/dictionaries/"
 dictionaries:
   - en_US

--- a/styles/Canonical/001-English-words-spelling-suggestions.yml
+++ b/styles/Canonical/001-English-words-spelling-suggestions.yml
@@ -3,6 +3,8 @@ message: "Use US English spelling, '%s' instead of '%s'."
 link: https://docs.ubuntu.com/styleguide/en/#spelling
 ignorecase: true
 level: suggestion
+scope:
+  - summary
 action:
   name: replace
 swap:

--- a/styles/Canonical/004-Canonical-product-names.yml
+++ b/styles/Canonical/004-Canonical-product-names.yml
@@ -3,6 +3,8 @@ message: "Use '%s' instead of '%s'"
 link: https://docs.ubuntu.com/styleguide/en/#other-canonical-products
 ignorecase: true
 level: error
+scope:
+  - summary
 action:
   name: replace
 swap:

--- a/styles/Canonical/005-Industry-product-names.yml
+++ b/styles/Canonical/005-Industry-product-names.yml
@@ -3,6 +3,8 @@ message: "Use '%s' instead of '%s'"
 link: https://docs.ubuntu.com/styleguide/en/#other-commonly-referenced-products/projects
 ignorecase: true
 level: error
+scope:
+  - summary
 action:
   name: replace
 swap:

--- a/styles/Canonical/006-Contractions-forbidden.yml
+++ b/styles/Canonical/006-Contractions-forbidden.yml
@@ -4,6 +4,8 @@ extends: substitution
 message: "Consider using '%s' instead of '%s'"
 link: https://docs.ubuntu.com/styleguide/en#contractions
 level: warning
+scope:
+  - summary
 ignorecase: true
 swap:
   ain[`']t: isn't

--- a/styles/Canonical/010-Punctuation-double-spaces.yml
+++ b/styles/Canonical/010-Punctuation-double-spaces.yml
@@ -4,6 +4,8 @@ extends: existence
 message: "'%s' should have one space."
 link: 
 level: warning
+scope:
+  - summary
 nonword: true
 tokens:
   - '[a-z][.?!] {2,}[A-Z]'

--- a/styles/Canonical/020-Cliche-words-and-phrases.yml
+++ b/styles/Canonical/020-Cliche-words-and-phrases.yml
@@ -4,6 +4,8 @@ extends: existence
 message: "Avoid the phrase '%s'"
 link: https://docs.ubuntu.com/styleguide/en#words-and-phrases-to-avoid
 level: warning
+scope:
+  - summary
 ignorecase: true
 tokens:
   - 'allow.*?'

--- a/styles/Canonical/025a-latinisms-with-english-equivalents.yml
+++ b/styles/Canonical/025a-latinisms-with-english-equivalents.yml
@@ -4,6 +4,8 @@ extends: substitution
 message: "Instead of '%[2]s', use %[1]s."
 link: https://docs.ubuntu.com/styleguide/en#latin-words-and-phrases
 level: suggestion
+scope:
+  - summary
 nonword: true
 ignorecase: true
 swap:

--- a/styles/Canonical/025b-latinisms-to-reconsider.yml
+++ b/styles/Canonical/025b-latinisms-to-reconsider.yml
@@ -4,6 +4,8 @@ extends: existence
 message: Instead of 'a.m.', 'AM', 'p.m.', and 'PM', use 24-hour time.
 link: https://docs.ubuntu.com/styleguide/en#latin-words-and-phrases
 level: suggestion
+scope:
+  - summary
 nonword: true
 tokens:
   - '\b[1|2]?:?\d?\d\s?(?:[AaPp]\.?[Mm]\.?)(?!\w+\b|\.)'

--- a/styles/Canonical/025c-latinisms-to-avoid.yml
+++ b/styles/Canonical/025c-latinisms-to-avoid.yml
@@ -4,6 +4,8 @@ extends: existence
 message: "Don't use academic Latin terms like 'a posteriori', 'et al', and 'stet'."
 link: https://docs.ubuntu.com/styleguide/en#latin-words-and-phrases
 level: warning
+scope:
+  - summary
 ignorecase: true
 tokens:
   - 'a\sposteriori'

--- a/styles/Canonical/400-Enforce-inclusive-terms.yml
+++ b/styles/Canonical/400-Enforce-inclusive-terms.yml
@@ -1,6 +1,8 @@
 extends: existence
 message: "Replace '%s' with an inclusive term"
 level: error
+scope:
+  - summary
 ignorecase: true
 tokens:
   - white(\-)?list(ed|ing)?

--- a/styles/Canonical/500-Repeated-words.yml
+++ b/styles/Canonical/500-Repeated-words.yml
@@ -1,6 +1,8 @@
 extends: repetition
 message: "'%s' is repeated!"
 level: warning
+scope:
+  - summary
 alpha: true
 ignorecase: true
 tokens:

--- a/vale.ini
+++ b/vale.ini
@@ -41,9 +41,9 @@ Canonical.500-Repeated-words = NO
 BasedOnStyles = Canonical
 
 # inline literal roles
-TokenIgnores = :relatedlinks:, ``.+?``, :samp:`.+?`, :file:`.+?`, :command:`.+?`, :doc:`.+?`
-TokenIgnores = :program:`.+?`, :literal:`.+?`, :kbd:`.+?`, :file:`.+?`, :math:`.+?`
-TokenIgnores = :token:`.+?`, :regexp:`.+?`, :command:`.+?`, :option:`.+?`, :envvar:`.+?`
+TokenIgnores = (:relatedlinks:), (``.+?``), (:samp:`.+?`), (:file:`.+?`), (:command:`.+?`), (:doc:`.+?`)
+TokenIgnores = (:program:`.+?`), (:literal:`.+?`), (:kbd:`.+?`), (:math:`.+?`)
+TokenIgnores = (:token:`.+?`), (:regexp:`.+?`), (:command:`.+?`), (:option:`.+?`), (:envvar:`.+?`)
 
 # links defined elsewhere
-TokenIgnores = \`\w+\`_
+TokenIgnores = (\`\w+\`_)


### PR DESCRIPTION
Rules with no scope are applied to all RST output, without respecting IgnoredScopes or IgnoredClasses.
TokenIgnores require brackets to apply to all relevant cases.