### PR TITLE
Add required terms to Vale accepted words list

### DIFF
--- a/styles/config/vocabularies/Canonical/accept.txt
+++ b/styles/config/vocabularies/Canonical/accept.txt
@@ -131,6 +131,7 @@ HWE
 IC
 IHV
 Imagecraft
+Indico
 Infiniband
 Influxdb
 init
@@ -249,6 +250,7 @@ POSIX
 PostgreSQL
 PPA
 ppc
+Prometheus
 PS5
 Pushgateway
 PXE
@@ -262,6 +264,7 @@ Rasterization
 RBAC
 RDMA
 Rebase
+Redis
 RegEx
 REPL
 Requirer
@@ -274,6 +277,7 @@ RoSRM
 RoST
 RTOS
 S3
+SAML
 SATA
 Scrcpy
 SDK
@@ -284,6 +288,7 @@ SFDC
 SIP
 SKU
 SLA
+SMTP
 Snapcraft
 snapcrafting
 Snapd
@@ -300,6 +305,7 @@ Squashfs
 SR
 SRU
 SSH
+StatsD
 subcluster
 Subnet
 Superdistro


### PR DESCRIPTION
This PR adds a few project-specific terms found in the [Indico Operator](https://github.com/canonical/indico-operator) documentation to the accept.txt whitelist. These words are valid in context and were previously triggering false positives in Vale style checks.

This helps reduce noise in future documentation audits and ensures smoother CI compliance.