### PR TITLE
fix: use sentence + list scope over summary

### DIFF
--- a/styles/Canonical/000-US-spellcheck.yml
+++ b/styles/Canonical/000-US-spellcheck.yml
@@ -3,7 +3,8 @@ extends: spelling
 message: "The word '%s' seems to be misspelled."
 level: error
 scope:
-  - summary
+  - sentence
+  - list
   - table.header
   - table.cell
 dicpath: "config/dictionaries/"

--- a/styles/Canonical/001-English-words-spelling-suggestions.yml
+++ b/styles/Canonical/001-English-words-spelling-suggestions.yml
@@ -4,7 +4,8 @@ link: https://docs.ubuntu.com/styleguide/en/#spelling
 ignorecase: true
 level: suggestion
 scope:
-  - summary
+  - sentence
+  - list
   - table.header
   - table.cell
 action:

--- a/styles/Canonical/003-Ubuntu-names-versions.yml
+++ b/styles/Canonical/003-Ubuntu-names-versions.yml
@@ -7,7 +7,8 @@ link: https://docs.ubuntu.com/styleguide/en/#ubuntu
 nonword: true
 ignorecase: true
 scope: 
-  - summary
+  - sentence
+  - list
   - heading
   - table.header
   - table.cell

--- a/styles/Canonical/004-Canonical-product-names.yml
+++ b/styles/Canonical/004-Canonical-product-names.yml
@@ -4,7 +4,8 @@ link: https://docs.ubuntu.com/styleguide/en/#other-canonical-products
 ignorecase: true
 level: error
 scope:
-  - summary
+  - sentence
+  - list
   - heading
   - table.header
   - table.cell

--- a/styles/Canonical/005-Industry-product-names.yml
+++ b/styles/Canonical/005-Industry-product-names.yml
@@ -4,7 +4,8 @@ link: https://docs.ubuntu.com/styleguide/en/#other-commonly-referenced-products/
 ignorecase: true
 level: error
 scope:
-  - summary
+  - sentence
+  - list
   - heading
   - table.header
   - table.cell

--- a/styles/Canonical/006-Contractions-forbidden.yml
+++ b/styles/Canonical/006-Contractions-forbidden.yml
@@ -5,7 +5,8 @@ message: "Consider using '%s' instead of '%s'"
 link: https://docs.ubuntu.com/styleguide/en#contractions
 level: warning
 scope:
-  - summary
+  - sentence
+  - list
   - heading
   - table.header
   - table.cell

--- a/styles/Canonical/010-Punctuation-double-spaces.yml
+++ b/styles/Canonical/010-Punctuation-double-spaces.yml
@@ -5,7 +5,8 @@ message: "'%s' should have one space."
 link: 
 level: warning
 scope:
-  - summary
+  - sentence
+  - list
 nonword: true
 tokens:
   - '[a-z][.?!] {2,}[A-Z]'

--- a/styles/Canonical/020-Cliche-words-and-phrases.yml
+++ b/styles/Canonical/020-Cliche-words-and-phrases.yml
@@ -5,7 +5,8 @@ message: "Avoid the phrase '%s'"
 link: https://docs.ubuntu.com/styleguide/en#words-and-phrases-to-avoid
 level: warning
 scope:
-  - summary
+  - sentence
+  - list
   - heading
   - table.header
   - table.cell

--- a/styles/Canonical/025a-latinisms-with-english-equivalents.yml
+++ b/styles/Canonical/025a-latinisms-with-english-equivalents.yml
@@ -5,7 +5,8 @@ message: "Instead of '%[2]s', use %[1]s."
 link: https://docs.ubuntu.com/styleguide/en#latin-words-and-phrases
 level: suggestion
 scope:
-  - summary
+  - sentence
+  - list
   - heading
   - table.header
   - table.cell

--- a/styles/Canonical/025b-latinisms-to-reconsider.yml
+++ b/styles/Canonical/025b-latinisms-to-reconsider.yml
@@ -5,7 +5,8 @@ message: Instead of 'a.m.', 'AM', 'p.m.', and 'PM', use 24-hour time.
 link: https://docs.ubuntu.com/styleguide/en#latin-words-and-phrases
 level: suggestion
 scope:
-  - summary
+  - sentence
+  - list
   - heading
   - table.header
   - table.cell

--- a/styles/Canonical/025c-latinisms-to-avoid.yml
+++ b/styles/Canonical/025c-latinisms-to-avoid.yml
@@ -5,7 +5,8 @@ message: "Don't use academic Latin terms like 'a posteriori', 'et al', and 'stet
 link: https://docs.ubuntu.com/styleguide/en#latin-words-and-phrases
 level: warning
 scope:
-  - summary
+  - sentence
+  - list
   - heading
   - table.header
   - table.cell

--- a/styles/Canonical/400-Enforce-inclusive-terms.yml
+++ b/styles/Canonical/400-Enforce-inclusive-terms.yml
@@ -2,7 +2,8 @@ extends: existence
 message: "Replace '%s' with an inclusive term"
 level: error
 scope:
-  - summary
+  - sentence
+  - list
   - heading
   - table.header
   - table.cell

--- a/styles/Canonical/500-Repeated-words.yml
+++ b/styles/Canonical/500-Repeated-words.yml
@@ -2,7 +2,8 @@ extends: repetition
 message: "'%s' is repeated!"
 level: warning
 scope:
-  - summary
+  - sentence
+  - list
   - heading
   - table.header
   - table.cell


### PR DESCRIPTION
Some issue with Vale means that `summary` scope is no longer working. `sentence` and `list` scopes combined should address most of the relevant cases for now.