### PR TITLE
Remove lowercase juju from accept.txt

### DIFF
--- a/styles/config/vocabularies/Canonical/accept.txt
+++ b/styles/config/vocabularies/Canonical/accept.txt
@@ -147,7 +147,6 @@ ISV
 ITP
 JAAS
 jQuery
-juju
 Juju
 jujuc
 jujud


### PR DESCRIPTION
### Overview

Update `accept.txt` to remove "juju" from the list of acceptable Canonical spellings.

### Rationale 

Rule [004-Canonical-product-names](https://github.com/canonical/praecepta/blob/main/styles/Canonical/004-Canonical-product-names.yml) currently does not pick up on instances where "juju" appears in the text. "juju" (un-capitalized and not code-formatted) should not be included in the list of acceptable spellings.

To refer to Juju in text:
* When discussing the application manager, Juju should be capitalized.
* When discussing the CLI, `juju` should be code-formatted, so the style checker shouldn't get involved. The CLI shouldn't be referred to with "juju" (un-capitalized and not code-formatted).