### PR TITLE
feat(spelling): add more common industry terms

### DIFF
--- a/styles/config/vocabularies/Canonical/accept.txt
+++ b/styles/config/vocabularies/Canonical/accept.txt
@@ -64,6 +64,7 @@ Coturn
 CPC
 CPQ
 CPT
+CPUs
 CR
 CRD
 CRI
@@ -122,10 +123,12 @@ HAcluster
 HAP
 HAProxy
 Hockeypuck
+hostname
 HPC
 HTTP
 HTTPS
 HWE
+IAM
 IC
 IHV
 Imagecraft
@@ -144,6 +147,7 @@ Istio
 ISV
 ITP
 JAAS
+Jenkins
 jQuery
 Juju
 jujuc


### PR DESCRIPTION
Adding some common terms to the accept.txt file:
* CPUs: CPU seems to be an okay vocabulary word, but the plural form is not.
* hostname: common industry term
* IAM: abbreviation for Identity and Access Management
* Jenkins: common industry term