### PR TITLE
Fix vale workflow

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ runs:
           TEMP_DIR: ${{ runner.temp }}
           ACTION_DIR: ${{ github.action_path }}
       run: |
-      
+
         if ! test -d ./styles/Canonical; then
         mkdir -p styles/Canonical
         cp $ACTION_DIR/styles/Canonical/* styles/Canonical/


### PR DESCRIPTION
# Description

The vale workflow from the main branch is currently failing.
The following error occurs when i try to use the action from the main branch:

```
E201 Invalid value [/home/runner/work/opencti-operator/opencti-operator/styles/Canonical/000-US-spellcheck.yml:1:1]:

   1* # Uses the built-in dictionary and filters.
   2  extends: spelling
   3  message: "The word '%s' seems to be misspelled."

unable to resolve dicpath
```
This is occuring since the `styles/config/dictonaries` folder is not copied into the final destination.
