### PR TITLE
Update 006-Contractions-forbidden rule

### DIFF
--- a/styles/Canonical/006-Contractions-forbidden.yml
+++ b/styles/Canonical/006-Contractions-forbidden.yml
@@ -23,3 +23,4 @@ swap:
   might[`']ve: might have
   gonna: going to
   gotta: got to
+  o[`']clock: AM/PM

--- a/tests/data/manifest.yml
+++ b/tests/data/manifest.yml
@@ -116,14 +116,38 @@ rules:
   #       expect:
   #         triggers:
   #         severity:
-  # 006-Contractions-forbidden:
-  #   cases:
-  #     - id: valid
-  #       filetypes: [md, rst]
-  #       content:
-  #       expect:
-  #         triggers:
-  #         severity:
+  006-Contractions-forbidden:
+    cases:
+      - id: contractions-forbidden
+        filetypes: [md, rst]
+        content: |
+          This ain't a sentence that you want to read in documentation.
+          How'd you feel yesterday?
+          How'll you feel tomorrow?
+          I'd expect that this sentence will not pass quality checks.
+          Something's off with this sentence.
+          This sentence mayn't pass inspection.
+          Our checks may've backfired.
+          This sentence mightn't pass inspection.
+          Our checks might've backfired.
+          We're gonna have to change some sentences.
+          We gotta make changes to the documentation.
+          We will make the changes at 10 o'clock.
+        expect:
+          triggers:
+            - ain't
+            - How'd
+            - How'll
+            - I'd
+            - Something's
+            - mayn't
+            - may've
+            - mightn't
+            - might've
+            - gonna
+            - gotta
+            - o'clock
+          severity: warning
   # 007-Headings-sentence-case:
   #   cases:
   #     - id: valid


### PR DESCRIPTION
Closes https://github.com/canonical/documentation-style-guide/issues/147

Updates rule 006 to include o'clock to the discouraged words. I also added a test for the rule and verified that it passes locally.

The rule was already at the level of "warning" so I didn't adjust the severity.