### PR TITLE
Simplify/streamline `vale.ini` formatting

### DIFF
--- a/vale.ini
+++ b/vale.ini
@@ -11,17 +11,17 @@ BasedOnStyles = Canonical
 
 Canonical.000-US-spellcheck = error
 Canonical.001-English-words-spelling-suggestions  = suggest
-Canonical.003-Ubuntu-names-versions = error              
-Canonical.005-Industry-product-names = error             
-Canonical.006-Contractions-forbidden = warning             
-Canonical.007-Headings-sentence-case = error           
-Canonical.008-Headings-no-period = warning               
-Canonical.009-Headings-no-links = warning                
-Canonical.010-Punctuation-double-spaces = warning         
+Canonical.003-Ubuntu-names-versions = error
+Canonical.005-Industry-product-names = error
+Canonical.006-Contractions-forbidden = warning
+Canonical.007-Headings-sentence-case = error
+Canonical.008-Headings-no-period = warning
+Canonical.009-Headings-no-links = warning
+Canonical.010-Punctuation-double-spaces = warning
 Canonical.011-Headings-not-followed-by-heading = warning
 Canonical.012-Date-format = warning
-Canonical.013-Spell-out-numbers-below-10 = warning                                   
-Canonical.014a-Numbers-greater-than-nine-should-be-in-numeric-form = suggest         
+Canonical.013-Spell-out-numbers-below-10 = warning
+Canonical.014a-Numbers-greater-than-nine-should-be-in-numeric-form = suggest
 Canonical.014b-Numbers-with-five-or-more-digits-must-have-comma-separators  = suggest
 Canonical.015-No-prompts-in-comments = warning
 Canonical.016-No-inline-comments = warning
@@ -39,10 +39,9 @@ TokenIgnores = ({vale-ignore}`.+?`), ({woke-ignore}`.+?`)
 BasedOnStyles = Canonical
 
 # inline literal roles
-TokenIgnores = (:relatedlinks:), (``.+?``), (:samp:`.+?`), (:file:`.+?`), (:command:`.+?`), (:doc:`.+?`)
-TokenIgnores = (:program:`.+?`), (:literal:`.+?`), (:kbd:`.+?`), (:math:`.+?`), (:literalref:`.+?`)
-TokenIgnores = (:token:`.+?`), (:regexp:`.+?`), (:command:`.+?`), (:option:`.+?`), (:envvar:`.+?`)
-TokenIgnores = (:vale-ignore:`.+?`), (:woke-ignore:`.+?`)
+TokenIgnores = (:relatedlinks:)
+TokenIgnores = (:(command|envvar|file|kbd|literal|literalref|math|option|program|regexp|samp|token)?:`.+?`)
+TokenIgnores = (:vale-ignore|woke-ignore:`.+?`)
 
 # Directive names
 TokenIgnores = (.. \w+::)


### PR DESCRIPTION
* Remove trailing spaces
* Group TokenIgnores directive rules
* Remove duplicate and unnecessary rules
   * removed:
       ```
       (``.+?``), (:doc:`.+?`)
       ```
     because those are ignored by default