### PR TITLE
fix: ignore external intersphinx roles

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -295,7 +295,7 @@ def manifest_schema(manifest: Manifest) -> Dict[str, Any]:
     return manifest.model_json_schema()
 
 
-def _test_markdown(markdown_input: str):
+def _test_raw(input: str, lang=".md"):
     vale_bin = shutil.which("vale")
     if not vale_bin:
         pytest.skip("'vale' binary not found on PATH; skipping test.")
@@ -304,16 +304,16 @@ def _test_markdown(markdown_input: str):
         "--config",
         VALE_CONFIG,
         "--ext",
-        ".md",
+        lang,
     ]
     subprocess.run(
         vale_cmd,
-        input=markdown_input,
+        input=input,
         text=True,
         check=True,
     )
 
 
 @pytest.fixture
-def test_markdown():
-    return _test_markdown
+def test_raw():
+    return _test_raw

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -295,7 +295,7 @@ def manifest_schema(manifest: Manifest) -> Dict[str, Any]:
     return manifest.model_json_schema()
 
 
-def _test_raw(input: str, lang=".md"):
+def _test_raw(input: str, lang: str = ".md"):
     vale_bin = shutil.which("vale")
     if not vale_bin:
         pytest.skip("'vale' binary not found on PATH; skipping test.")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -268,3 +268,20 @@ def test_md_role_intersphinx_links(test_raw):
         ),
         ".md",
     )
+
+def test_rst_role_intersphinx_links(test_raw):
+    """Case with links to Intersphinx project:
+
+    - An external Intersphinx ref.
+    - An external Intersphinx doc."""
+
+    test_raw(
+        textwrap.dedent(
+            """
+            :external+launchpad:ref:`test`
+
+            :external+launchpad:doc:`test`
+            """
+        ),
+        ".rst",
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,92 +3,98 @@
 import textwrap
 
 
-def test_colon_fence_arbitrary(test_markdown):
+def test_md_colon_fence_arbitrary(test_raw):
     """Case with starting fence with arbitrary directive."""
 
-    test_markdown(
+    test_raw(
         textwrap.dedent(
             """
             :::{lorem} ipsum
             """
-        )
+        ),
+        ".md",
     )
 
 
-def test_colon_fence_code(test_markdown):
+def test_md_colon_fence_code(test_raw):
     """Case with colon-fenced `code` directive."""
 
-    test_markdown(
+    test_raw(
         textwrap.dedent(
             """
             :::{code}
             lorem
             :::
             """
-        )
+        ),
+        ".md",
     )
 
 
-def test_colon_fence_code_block(test_markdown):
+def test_md_colon_fence_code_block(test_raw):
     """Case with colon-fenced `code-block` directive."""
 
-    test_markdown(
+    test_raw(
         textwrap.dedent(
             """
             :::{code-block}
             lorem
             :::
             """
-        )
+        ),
+        ".md",
     )
 
 
-def test_colon_fence_sourcecode(test_markdown):
+def test_md_colon_fence_sourcecode(test_raw):
     """Case with colon-fenced `sourcecode` directive."""
 
-    test_markdown(
+    test_raw(
         textwrap.dedent(
             """
             :::{sourcecode}
             lorem
             :::
             """
-        )
+        ),
+        ".md",
     )
 
 
-def test_colon_fence_terminal(test_markdown):
+def test_md_colon_fence_terminal(test_raw):
     """Case with colon-fenced `terminal` directive."""
 
-    test_markdown(
+    test_raw(
         textwrap.dedent(
             """
             :::{terminal}
             lorem
             :::
             """
-        )
+        ),
+        ".md",
     )
 
 
-def test_colon_fence_toctree(test_markdown):
+def test_md_colon_fence_toctree(test_raw):
     """Case with colon-fenced `toctree` directive."""
 
-    test_markdown(
+    test_raw(
         textwrap.dedent(
             """
             :::{toctree}
             lorem
             :::
             """
-        )
+        ),
+        ".md",
     )
 
 
-def test_colon_fence_parameter_options(test_markdown):
+def test_md_colon_fence_parameter_options(test_raw):
     """Case with a colon-fenced literal containing space and a parameter."""
 
-    test_markdown(
+    test_raw(
         textwrap.dedent(
             """
             ::: {code} python
@@ -97,14 +103,15 @@ def test_colon_fence_parameter_options(test_markdown):
             lorem
             :::
             """
-        )
+        ),
+        ".md",
     )
 
 
-def test_colon_fence_serial(test_markdown):
+def test_md_colon_fence_serial(test_raw):
     """Case with two colon-fenced literal directives separated by another block."""
 
-    test_markdown(
+    test_raw(
         textwrap.dedent(
             """
             :::{code}
@@ -117,29 +124,31 @@ def test_colon_fence_serial(test_markdown):
             ipsum
             :::
             """
-        )
+        ),
+        ".md",
     )
 
 
-def test_colon_fence_final_spaces(test_markdown):
+def test_md_colon_fence_final_spaces(test_raw):
     """Case with a colon-fenced literal directive with spaces after the closing
     fence."""
 
-    test_markdown(
+    test_raw(
         textwrap.dedent(
             """
             :::{code}
             lorem
             :::    
             """
-        )
+        ),
+        ".md",
     )
 
 
-def test_colon_fence_special_chars(test_markdown):
+def test_md_colon_fence_special_chars(test_raw):
     """Case with a colon-fenced literal containing all special characters."""
 
-    test_markdown(
+    test_raw(
         textwrap.dedent(
             """
             :::{code}
@@ -177,14 +186,15 @@ def test_colon_fence_special_chars(test_markdown):
             ?
             :::
             """
-        )
+        ),
+        ".md",
     )
 
 
-def test_colon_fence_colons(test_markdown):
+def test_md_colon_fence_colons(test_raw):
     """Case with a colon-fenced literal directive containing unescaped colons."""
 
-    test_markdown(
+    test_raw(
         textwrap.dedent(
             """
             :::{code}
@@ -197,31 +207,33 @@ def test_colon_fence_colons(test_markdown):
 
             :::
             """
-        )
+        ),
+        ".md",
     )
 
 
-def test_colon_fence_multiple(test_markdown):
+def test_md_colon_fence_multiple(test_raw):
     """Case with a literal directive fenced with more than three colons."""
 
-    test_markdown(
+    test_raw(
         textwrap.dedent(
             """
             ::::{code}
             lorem
             ::::
             """
-        )
+        ),
+        ".md",
     )
 
 
-def test_colon_fence_nested(test_markdown):
+def test_md_colon_fence_nested(test_raw):
     """Case with a colon-fenced non-literal directive containing:
 
     - A child that is a colon-fenced literal directive.
     - A child that is a colon-fenced non-literal directive."""
 
-    test_markdown(
+    test_raw(
         textwrap.dedent(
             """
             ::::{admonition} Level 1
@@ -236,21 +248,23 @@ def test_colon_fence_nested(test_markdown):
 
             ::::
             """
-        )
+        ),
+        ".md",
     )
 
-def test_role_intersphinx_links(test_markdown):
+def test_md_role_intersphinx_links(test_raw):
     """Case with links to Intersphinx project:
 
     - An external Intersphinx ref.
     - An external Intersphinx doc."""
 
-    test_markdown(
+    test_raw(
         textwrap.dedent(
             """
             {external+launchpad:ref}`test`
 
             {external+launchpad:doc}`test`
             """
-        )
+        ),
+        ".md",
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -238,3 +238,19 @@ def test_colon_fence_nested(test_markdown):
             """
         )
     )
+
+def test_role_intersphinx_links(test_markdown):
+    """Case with links to Intersphinx project:
+
+    - An external Intersphinx ref.
+    - An external Intersphinx doc."""
+
+    test_markdown(
+        textwrap.dedent(
+            """
+            {external+launchpad:ref}`test`
+
+            {external+launchpad:doc}`test`
+            """
+        )
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -252,6 +252,7 @@ def test_md_colon_fence_nested(test_raw):
         ".md",
     )
 
+
 def test_md_role_intersphinx_links(test_raw):
     """Case with links to Intersphinx project:
 
@@ -261,13 +262,15 @@ def test_md_role_intersphinx_links(test_raw):
     test_raw(
         textwrap.dedent(
             """
+            {external:ref}`test`
+            {external:py:class}`test`
             {external+launchpad:ref}`test`
-
             {external+launchpad:doc}`test`
             """
         ),
         ".md",
     )
+
 
 def test_rst_role_intersphinx_links(test_raw):
     """Case with links to Intersphinx project:
@@ -278,8 +281,9 @@ def test_rst_role_intersphinx_links(test_raw):
     test_raw(
         textwrap.dedent(
             """
+            :external:ref:`test`
+            :external:py:class:`test`
             :external+launchpad:ref:`test`
-
             :external+launchpad:doc:`test`
             """
         ),

--- a/vale.ini
+++ b/vale.ini
@@ -39,6 +39,8 @@ BasedOnStyles = Canonical
 
 # Ignore custom spelling role
 TokenIgnores = ({(vale-ignore|woke-ignore)}`.+?`)
+# Ignore technical roles
+TokenIgnores = (\{external(\+\w+?:(doc|ref))?\}`.+?`)
 
 # Ignore opening colon-fenced (:::) lines and colon-fenced literal directives
 # The listed directives must be in sync with the [*.rst] `BlockIgnores`
@@ -53,7 +55,7 @@ BasedOnStyles = Canonical
 TokenIgnores = (:(vale-ignore|woke-ignore):`.+?`)
 # Ignore technical roles
 TokenIgnores = (:relatedlinks:)
-TokenIgnores = (:(command|envvar|file|kbd|literal|literalref|math|option|program|regexp|samp|token)?:`.+?`)
+TokenIgnores = (:(command|envvar|file|kbd|literal|literalref|math|option|program|regexp|samp|token|external(\+\w+?:(doc|ref))?):`.+?`)
 # Ignore directives
 TokenIgnores = (.. \w+::)
 # Ignore options

--- a/vale.ini
+++ b/vale.ini
@@ -40,7 +40,7 @@ BasedOnStyles = Canonical
 # Ignore custom spelling role
 TokenIgnores = ({(vale-ignore|woke-ignore)}`.+?`)
 # Ignore technical roles
-TokenIgnores = (\{external(\+\w+?:(doc|ref))?\}`.+?`)
+TokenIgnores = (\{external[\w+:]+?\}`.+?`)
 
 # Ignore opening colon-fenced (:::) lines and colon-fenced literal directives
 # The listed directives must be in sync with the [*.rst] `BlockIgnores`
@@ -55,7 +55,7 @@ BasedOnStyles = Canonical
 TokenIgnores = (:(vale-ignore|woke-ignore):`.+?`)
 # Ignore technical roles
 TokenIgnores = (:relatedlinks:)
-TokenIgnores = (:(command|envvar|file|kbd|literal|literalref|math|option|program|regexp|samp|token|external(\+\w+?:(doc|ref))?):`.+?`)
+TokenIgnores = (:(command|envvar|file|kbd|literal|literalref|math|option|program|regexp|samp|token|external[\w+:]+?):`.+?`)
 # Ignore directives
 TokenIgnores = (.. \w+::)
 # Ignore options


### PR DESCRIPTION
- Ignore the roles in the config.
- Make config check work for reST snippets.
- Add tests to check whether they're ignored.

Resolves #185.