### PR TITLE
fix: reduce false positives in rules 003, 004, and 400

### DIFF
--- a/styles/Canonical/003-Ubuntu-names-versions.yml
+++ b/styles/Canonical/003-Ubuntu-names-versions.yml
@@ -16,8 +16,9 @@ scope:
 level: error
 tokens:
   # LTS releases should be followed by "LTS" suffix.
-  - 'Ubuntu \d?[02468]\.04(?! LTS)'
-  - 'Ubuntu 6\.06(?! LTS)'
+  # Use (?!\.\d| LTS) so point releases like "Ubuntu 24.04.4 LTS" are not flagged.
+  - 'Ubuntu \d?[02468]\.04(?!\.\d| LTS)'
+  - 'Ubuntu 6\.06(?!\.\d| LTS)'
   # Non-LTS releases should not be followed by "LTS" suffix.
   - 'Ubuntu \d?\d\.10 LTS'
   - 'Ubuntu \d?[13579]\.04 LTS'

--- a/styles/Canonical/004-Canonical-product-names.yml
+++ b/styles/Canonical/004-Canonical-product-names.yml
@@ -31,7 +31,8 @@ swap:
   Snapcraft: Snapcraft
   snapd: snapd # Vale seems to allow normal capitalisation, may need specific existence rule for Snapd
   Ubuntu Core: Ubuntu Core
-  (?<=Ubuntu )Pro: Pro
+  # \b ensures only "Ubuntu Pro" matches, not "Ubuntu project", "Ubuntu provides", etc.
+  (?<=Ubuntu )Pro\b: Pro
   Ubuntu Server: Ubuntu Server
 
 # Not working with multi-word terms that have the first word in the accept list

--- a/styles/Canonical/400-Enforce-inclusive-terms.yml
+++ b/styles/Canonical/400-Enforce-inclusive-terms.yml
@@ -14,7 +14,7 @@ tokens:
   - black( )?hats?
   - white( )?hats?
   - illegal characters?
-  - masters?
+  - (?<!\/)masters?
   - (?<!jenkins\-)slaves?
   - chairman
   - foreman

--- a/tests/data/manifest.yml
+++ b/tests/data/manifest.yml
@@ -60,6 +60,8 @@ rules:
           Ubuntu 24.04 LTS
           Ubuntu 24.04 LTS (Noble)
           Ubuntu 24.04 LTS (Noble Numbat)
+          Ubuntu 24.04.4 LTS
+          Ubuntu 24.04.4 LTS (Noble Numbat)
 
           ## Ubuntu 24.04 LTS
 
@@ -120,6 +122,18 @@ rules:
             - snapcraft
             - snapD
             - SnapD
+            - pro
+          severity: error
+      - id: ubuntu-pro-not-flagged
+        filetypes: [md, rst]
+        content: |
+          The Ubuntu project is open source.
+          Ubuntu provides a range of tools.
+          Ubuntu proposed-migration is a process.
+          See the Ubuntu Pro page for subscription info.
+          Ubuntu pro is a product.
+        expect:
+          triggers:
             - pro
           severity: error
   005-Industry-product-names:


### PR DESCRIPTION
Fixes three sources of false positives discovered while running these rules against [ubuntu-project-docs](https://github.com/ubuntu/ubuntu-project-docs).

### Rule 003 — point releases falsely flagged

`Ubuntu \d?[02468]\.04(?! LTS)` fires on `Ubuntu 24.04.4 LTS` because after `24.04` the lookahead sees `.4`, not ` LTS`.


### Rule 004 — "Ubuntu Pro" matches "Ubuntu project", "Ubuntu provides", etc.

`nonword: true` disables implicit word boundaries, so `(?<=Ubuntu )Pro` matches any word that begins with "pro" after "Ubuntu ". This triggers on valid prose like "Ubuntu project", "Ubuntu provides", "Ubuntu proposed-migration".

**Fix:** Add an explicit word boundary: `(?<=Ubuntu )Pro\b`.

### Rule 400 — "master" in URL paths

The token `masters?` fires on "master" inside URL path components (e.g. `.../blob/master/README.md`) which are not uses of the term.

All existing tests pass and new test cases are added for the 003 and 004 fixes.

---

Done with Copilot + Claude Sonnet.