### PR TITLE
fix: Accept "AI" in sentence-case headings

### DIFF
--- a/styles/config/vocabularies/Canonical/accept.txt
+++ b/styles/config/vocabularies/Canonical/accept.txt
@@ -11,6 +11,7 @@ ABI
 ACLs
 ADB
 ADSys
+AI
 AKS
 allowlist
 AMC


### PR DESCRIPTION
Support has a knowledge base article category for "AI and data", which breaks on this vale rule.
```
 100:5  warning  'AI and data' should use        Canonical.007-Headings-sentence-case
                 sentence-style capitalisation.
```

This fix resolves it.