### PR TITLE
fix: remove duplicate link key in 027-non-descriptive-link-text.yml

### DIFF
--- a/styles/Canonical/027-non-descriptive-link-text.yml
+++ b/styles/Canonical/027-non-descriptive-link-text.yml
@@ -4,7 +4,6 @@
 
 extends: existence
 message: "Use descriptive link text instead of '%s' to improve accessibility."
-link: https://canonical-documentation-style-guide.readthedocs-hosted.com/
 link: https://docs.ubuntu.com/styleguide/en
 scope: raw
 nonword: true


### PR DESCRIPTION
## Problem

`styles/Canonical/027-non-descriptive-link-text.yml` contains two `link:` keys:

```yaml
link: https://canonical-documentation-style-guide.readthedocs-hosted.com/
link: https://docs.ubuntu.com/styleguide/en
```

Duplicate keys are invalid YAML. go-yaml (used by Vale) silently discards the first value, leaving the `extends` field unreadable. This causes Vale to abort with a misleading error:

```
E201 'extends' key must be one of [capitalization conditional consistency existence ...]
```

The real cause is the YAML parse failure on the duplicate key, not an invalid `extends` value. This breaks the `docs-checks / vale` CI job in any repository that transitively pulls this style file (e.g. via `canonical/platform-engineering-vale-package`).

## Fix

Remove the duplicate `link:` line, keeping `https://docs.ubuntu.com/styleguide/en` as the single reference.