### PR TITLE
Fix regex for 'viz' in Latinisms YAML

### DIFF
--- a/styles/Canonical/025a-latinisms-with-english-equivalents.yml
+++ b/styles/Canonical/025a-latinisms-with-english-equivalents.yml
@@ -29,4 +29,4 @@ swap:
   \bstatus\squo\b: "'state' or 'state of things'"
   \b(?:versus|vs\.(?!\w)|vs(?![\.\w])): "'compared to/with' or 'opposed to'"
   \bvice\sversa\b: "'the reverse' or 'the other way around'"
-  \b(viz\.(?!\w)|viz(?![\w\.])): "'specifically' or 'namely'"
+  \b(?:viz\.(?!\w)|viz(?![\w\.])): "'specifically' or 'namely'"


### PR DESCRIPTION
This PR adds `viz.` (short for *videlicet*) to the list of discouraged Latin abbreviations

### Regex Details
The regex is designed to avoid false-positive matches on domains, emails, and overlapping words (e.g. `viz.com`, `vizier`, `supervise`):
```yaml
\b(?:viz\.(?!\w)|viz(?![\w\.])): "'specifically' or 'namely'"
```
* **`viz\.(?!\w)`**: Matches `viz.` only if the dot is not followed by a word character (catches `"viz. "`, misses `"viz.com"`).
* **`viz(?![\w\.])`**: Matches `viz` only if the word is not followed by a word character or a dot (catches `"viz, "`, misses `"vizier"`).

### Verification
Testing this against the following markdown confirms correct behavior:

```markdown
<!-- Triggers warning: -->
Please provide the details, viz. the names and dates.
We have three options, viz, red, green, and blue.
The results are clear viz the chart below.

<!-- Passes silently (no false positives): -->
The vizier advised the sultan.
Check the website at viz.com or viz.org.
We need to supervise the process.
```