### PR TITLE
fix: allow "Master Boot Record" despite inclusive terms

### DIFF
--- a/styles/Canonical/400-Enforce-inclusive-terms.yml
+++ b/styles/Canonical/400-Enforce-inclusive-terms.yml
@@ -15,7 +15,7 @@ tokens:
   - black( )?hats?
   - white( )?hats?
   - illegal characters?
-  - (?<!\/)masters?
+  - (?<!\/)\bmasters?\b(?!\s+boot\s+records?\b)
   - (?<!jenkins\-)slaves?
   - chairman
   - foreman


### PR DESCRIPTION
The term "Master Boot Record" unfortunately needs to remain available for some projects, so this allows that term specifically while still flagging most usages of "master."

Regexp test: https://regex101.com/?regex=%28%3F%3C%21%5C%2F%29%5Cbmasters%3F%5Cb%28%3F%21%5Cs%2Bboot%5Cs%2Brecords%3F%5Cb%29&testString=%2Fmaster%2F%0Amaster+%0Amaster+mind%0Amastermind%0Amaster+boot+record%0Amaster%2Fslave%0Amaster-slave&flags=gm&flavor=dotnet&delimiter=%22