### PR TITLE
fix: ignore RST and MD target labels via global TokenIgnores

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -289,3 +289,51 @@ def test_rst_role_intersphinx_links(test_raw):
         ),
         ".rst",
     )
+
+
+def test_md_target_labels(test_raw):
+    """Case with labels that contain:
+
+    - A misspelled product name.
+    - A spelling error.
+    - A digit instead of a spelled-out number below ten.
+    - Indentation before and after."""
+
+    test_raw(
+        textwrap.dedent(
+            """
+            (launchpad)=
+
+            (splelling)=
+
+            (test-1)=
+
+                (test)=  
+            """
+        ),
+        ".md",
+    )
+
+
+def test_rst_target_labels(test_raw):
+    """Case with labels that contain:
+
+    - A misspelled product name.
+    - A spelling error.
+    - A digit instead of a spelled-out number below ten.
+    - Indentation before and after."""
+
+    test_raw(
+        textwrap.dedent(
+            """
+            .. _launchpad:
+
+            .. _splelling:
+
+            .. _test-1:
+
+                .. _test:  
+            """
+        ),
+        ".rst",
+    )

--- a/vale.ini
+++ b/vale.ini
@@ -42,6 +42,8 @@ BasedOnStyles = Canonical
 TokenIgnores = ({(vale-ignore|woke-ignore)}`.+?`)
 # Ignore technical roles
 TokenIgnores = (\{external[\w+:]+?\}`.+?`)
+# Ignore target labels
+TokenIgnores = (\(([a-z0-9-]+)\)=)
 
 # Ignore opening colon-fenced (:::) lines and colon-fenced literal directives
 # The listed directives must be in sync with the [*.rst] `BlockIgnores`
@@ -63,6 +65,8 @@ TokenIgnores = (.. \w+::)
 TokenIgnores = (:\w+: \w+), (:\w+:)
 # Ignore external links
 TokenIgnores = (\`\w+\`_)
+# Ignore target labels
+TokenIgnores = (\.\. _([a-z0-9-]+):)
 
 # Spelling not respecting code blocks
 # The listed directives must be in sync with the [*.md] `BlockIgnores`


### PR DESCRIPTION
Target labels (e.g. `.. _some-label:` in RST, `(some-label)=` in MD) are being linted by every active rule even though  labels are identifiers, not prose. Labels are typically lowercase, hyphenated, and often not full dictionary words.

The ignore is added at the vale.ini level instead of a single rule (e.g. 004) because target labels aren't specific to one check. A per-rule exception would need to be duplicated across every rule that happens to scan this text, whereas a single TokenIgnores excludes the label from tokenization once, upstream of all rules.

Added test cases to manifest.yml to confirm labels are no longer flagged in rule 004.